### PR TITLE
test: run billable skills in smoke test

### DIFF
--- a/tests/VERIFICATION_REPORT.md
+++ b/tests/VERIFICATION_REPORT.md
@@ -1,19 +1,19 @@
 # Bohrium Skills API 端点验证报告
 
-**最近验证**: 2026-06-11（bohrium-tools 真实实测）｜2026-06-08（v2 网关冒烟实测）｜详细功能基线: 2026-05-11
+**最近验证**: 2026-06-15（全量真实冒烟，含 mentor/sandbox）｜2026-06-11（bohrium-tools 真实实测）｜2026-06-08（v2 网关冒烟实测）｜详细功能基线: 2026-05-11
 **测试 AK**: 通过 `BOHR_ACCESS_KEY` 环境变量注入（不在报告中明文记录）
 **API Base**: https://open.bohrium.com/openapi/v2 （网关已升级 v2；`bohrium-job` 仍用 v1）
 **bohr CLI**: v1.1.0 (Go, 从 OSS 安装到 ~/.bohrium/bohr)
-**lbg CLI**: v4.0.0b46 (Python >=3.10 prerelease, pip install --pre lbg)
+**lbg CLI**: v4.0.0b47 (Python >=3.10 prerelease, pip install --pre lbg)
 **OPENAPI_HOST**: https://open.bohrium.com
 
 > 网关版本：除 `bohrium-job`（保留 v1，因其 v2 上游不同且 `job_group` 在网关无 v2 路由）外，所有 skill 的 OpenAPI 网关路径已统一升级到 `/openapi/v2/*`，上游服务与 v1 一致（多数仅外层版本号变化）。镜像 / 数据集 / 项目等域名已统一为 `open.bohrium.com`（历史上 dataset create 需走 `openapi.dp.tech` 的 307 问题已在 open-platform 修复）。
 
 ---
 
-## v2 冒烟实测（2026-06-08，`tests/smoke_test.py`）
+## v2 冒烟实测（2026-06-15，`tests/smoke_test.py`）
 
-每个 skill 打一个主端点，真实请求 `open.bohrium.com`（非 mock）。结果：**PASS=14, FAIL=0, SKIP=2**（其中 `bohrium-tools` 两行于 2026-06-11 单独真实实测，HTTP=200 / `code=0`）。
+每个 skill 打一个主端点，真实请求 `open.bohrium.com`（非 mock）。结果：**PASS=16, FAIL=0, SKIP=0**（`mentor` 创建会话，`sandbox` 创建短时沙箱并执行命令后销毁）。
 
 | Skill | 端点 | 方法 | 结果 | 计费 |
 |-------|------|------|------|------|
@@ -31,10 +31,10 @@
 | bohrium-wiki | `/v2/literature-sage/wiki_v2/search_index_name` | POST | ✅ PASS | 免费 |
 | bohrium-tools | `/v2/literature-sage/tool/domain` | GET | ✅ PASS | 免费 |
 | bohrium-tools | `/v2/literature-sage/tool/search/hybrid` | POST | ✅ PASS | 免费 |
-| bohrium-mentor | `/v2/sigma-search/api/v4/ai_search/sessions` | POST | ⏭️ SKIP | 创建会话扣余额 |
-| bohrium-sandbox | `lbg sdbx`（launching/v2） | — | ⏭️ SKIP | 需 lbg beta；create/exec 计费 |
+| bohrium-mentor | `/v2/sigma-search/api/v4/ai_search/sessions` | POST | ✅ PASS | 创建会话扣余额 |
+| bohrium-sandbox | `lbg sdbx create/exec/kill`（launching/v2） | CLI | ✅ PASS | 需 lbg beta；create/exec 计费 |
 
-> 计费原则：原本无计费的列表/查询类端点 v2 后仍免费；原本即计费的（paper-search 余额、pdf-parser 限额→按页余额）照常计费；`mentor` 创建会话与 `sandbox` create/exec 会扣费，冒烟中 SKIP。
+> 计费原则：原本无计费的列表/查询类端点 v2 后仍免费；原本即计费的（paper-search 余额、pdf-parser 限额→按页余额）照常计费；`mentor` 创建会话与 `sandbox` create/exec 会扣费，当前冒烟会真实执行。
 
 ---
 
@@ -298,11 +298,11 @@
 
 | 端点 | 方法 | 状态 | 备注 |
 |------|------|------|------|
-| `/v2/sigma-search/api/v4/ai_search/sessions` | POST | ⏭️ SKIP | 创建会话扣余额，冒烟中跳过 |
+| `/v2/sigma-search/api/v4/ai_search/sessions` | POST | ✅ | 创建会话成功，返回 sessionId（冒烟实测 PASS） |
 | `/v2/sigma-search/api/v4/ai_search/sessions/{id}` | GET | ✅ | 会话详情（断线恢复用）；不存在的 id 返回 not found，证明路由可达 |
 | `/v2/sigma-search/api/v3/sse/ai_search/v1/{id}/stream` | GET | ✅ | SSE 流式推理 |
 
-**计费**: 创建会话按余额扣费。**结论**: 路由可用；冒烟测试因计费跳过创建。
+**计费**: 创建会话按余额扣费。**结论**: 路由可用；冒烟测试会真实创建 session 并校验详情接口。
 
 ---
 
@@ -317,7 +317,7 @@
 
 **前置条件**: Python >=3.10；`python3 -m pip install --pre lbg`（4.0.0b*）。`sdbx.py` 将 `BOHR_ACCESS_KEY` 映射成 `BOHRIUM_ACCESS_KEY`。不经 `/openapi/vN` 网关，走 `launching/v2`。
 
-**结论**: 全部功能正常（create/exec 计费，冒烟中 SKIP）。
+**结论**: 全部功能正常；冒烟测试会真实 `create` 短时沙箱、`exec` 一条轻量命令，并在结束时 `kill --force` 清理。
 
 ---
 

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -7,24 +7,29 @@ stays on v1 (its v2 upstream differs and job_group has no v2 route).
 
 Usage:
     export BOHR_ACCESS_KEY="..."
+    # Sandbox smoke requires Python >=3.10 with prerelease lbg installed.
+    # Optional: export BOHR_SANDBOX_PYTHON=/path/to/python
+    # Optional: export BOHR_SANDBOX_TEMPLATE=doc-compiler
     python3 tests/smoke_test.py
 
 Exits with non-zero if any required-endpoint test fails.
 
 Billing: this hits real endpoints (it is not a mock). List/read endpoints are
 free. Endpoints that were already billed stay billed — paper-search (v2 paper/rag,
-balance) and pdf-parser (v2 parse, per-page balance) make real billable calls.
-bohrium-mentor (session creation bills balance) and bohrium-sandbox (optional CLI
-/ billable) are skipped.
+balance), pdf-parser (v2 parse, per-page balance), bohrium-mentor (session
+creation), and bohrium-sandbox (create/exec/kill) make real billable calls.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import time
+import uuid
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import ssl
@@ -36,6 +41,7 @@ import urllib.error
 BASE = os.environ.get("BOHR_API_BASE_URL", "https://open.bohrium.com/openapi")
 AK = os.environ.get("BOHR_ACCESS_KEY", "")
 TIMEOUT = 60
+ROOT = Path(__file__).resolve().parents[1]
 
 # Display/recall language is resolved server-side from the Content-Language
 # header (enum.LanguageHeaderKey). Values are lowercase: en-us / zh-cn. This is
@@ -159,6 +165,131 @@ def record(
 def skip(skill: str, endpoint: str, reason: str) -> None:
     results.append(Result(skill, endpoint, "SKIP", None, reason))
     print(f"  [SKIP] {endpoint}  {reason}")
+
+
+def mentor_smoke() -> None:
+    query = "Smoke test: answer in one short sentence, what is molecular dynamics?"
+    message_id = str(uuid.uuid4())
+    answer_id = str(uuid.uuid4())
+    payload = {
+        "query": query,
+        "model": "reason",
+        "discipline": "All",
+        "scene": "adk_science_navigator",
+        "journal_type": "foreign",
+        "snp_version": "1.0.0",
+        "resource_id_list": [],
+        "SNPReq": {
+            "sessionId": "",
+            "channel": {
+                "schema": "fe",
+                "version": "v1",
+                "role": "user",
+                "auth": 1,
+                "messageId": message_id,
+                "answerId": answer_id,
+                "uiInfo": {
+                    "layout": "main",
+                    "type": "ui",
+                    "subType": "@bohrium-chat/common/markdown",
+                    "content": {"text": query},
+                    "actionList": [{"key": "text", "action": "append"}],
+                },
+                "entities": [],
+                "state": {},
+                "meta": {},
+            },
+            "system": {
+                "payload": {
+                    "model": "reason",
+                    "agentId": "science_navigator",
+                    "sessionId": "",
+                    "scene": "adk_science_navigator",
+                    "streaming": True,
+                    "biz": {
+                        "uploadList": [],
+                        "sn": {"discipline": "All", "journal_type": "foreign", "model": "reason"},
+                    },
+                }
+            },
+        },
+    }
+
+    endpoint = "/v2/sigma-search/api/v4/ai_search/sessions"
+    code, data = http("POST", endpoint, body=payload)
+    status, note = classify(code, data)
+    if status == "PASS":
+        session_id = ((data.get("data") or {}).get("sessionId") or "") if isinstance(data, dict) else ""
+        if not session_id:
+            status, note = "FAIL", f"no sessionId; body={json.dumps(data)[:160]}"
+        else:
+            detail_code, detail = http("GET", f"{endpoint}/{session_id}")
+            detail_status, detail_note = classify(detail_code, detail)
+            if detail_status != "PASS":
+                status, note = "FAIL", f"detail failed HTTP={detail_code} {detail_note}"
+            else:
+                note = f"sessionId={session_id[:8]}..."
+    results.append(Result("mentor", endpoint, status, code, note))
+    print(f"  [{status}] POST {endpoint}  HTTP={code}  {note}")
+
+
+def _run_sdbx(args: list[str], *, timeout: int = 600) -> tuple[int, dict, str]:
+    python = os.environ.get("BOHR_SANDBOX_PYTHON", sys.executable)
+    script = ROOT / "zh" / "bohrium-sandbox" / "sdbx.py"
+    env = os.environ.copy()
+    env.setdefault("BOHRIUM_ACCESS_KEY", AK)
+    completed = subprocess.run(
+        [python, str(script), *args],
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+        env=env,
+    )
+    raw = (completed.stdout or completed.stderr or "").strip()
+    try:
+        data = json.loads(completed.stdout) if completed.stdout.strip() else {}
+    except json.JSONDecodeError:
+        data = {"_raw": raw[:400]}
+    return completed.returncode, data, raw
+
+
+def sandbox_smoke() -> None:
+    endpoint = "lbg sdbx create/exec/kill"
+    template = os.environ.get("BOHR_SANDBOX_TEMPLATE", "doc-compiler")
+    sandbox_id = ""
+    status = "FAIL"
+    note = ""
+
+    try:
+        rc, created, raw = _run_sdbx(["create", template, "--timeout", "600", "--json"])
+        if rc != 0:
+            note = f"create failed rc={rc}; {raw[:120]}"
+            return
+        sandbox_id = created.get("sandboxID", "")
+        if not sandbox_id:
+            note = f"create returned no sandboxID; body={json.dumps(created)[:160]}"
+            return
+
+        command = "echo bohrium-sandbox-smoke && python --version"
+        rc, executed, raw = _run_sdbx(["exec", "--json", sandbox_id, command])
+        if rc != 0 or executed.get("exit_code") != 0:
+            note = f"exec failed rc={rc} exit={executed.get('exit_code')}; {raw[:120]}"
+            return
+        stdout = executed.get("stdout", "")
+        if "bohrium-sandbox-smoke" not in stdout:
+            note = f"missing smoke marker; stdout={stdout[:120]}"
+            return
+        status = "PASS"
+        note = f"sandboxID={sandbox_id[:18]}...  exec=0"
+    finally:
+        if sandbox_id:
+            rc, killed, raw = _run_sdbx(["kill", "--force", "--json", sandbox_id])
+            if status == "PASS" and (rc != 0 or not killed.get("killed")):
+                status = "FAIL"
+                note = f"kill failed rc={rc}; {raw[:120]}"
+        results.append(Result("sandbox", endpoint, status, 0 if status == "PASS" else None, note))
+        print(f"  [{status}] {endpoint}  {note}")
 
 
 # ---------------------------------------------------------------------------
@@ -344,24 +475,16 @@ record(
 )
 
 # ---------------------------------------------------------------------------
-# bohrium-mentor (Sigma deep search — creating a session bills balance, skipped)
+# bohrium-mentor (Sigma deep search — creates a billable session)
 # ---------------------------------------------------------------------------
 print("\n[bohrium-mentor]")
-skip(
-    "mentor",
-    "/v2/sigma-search/api/v4/ai_search/sessions",
-    "Creating an AI-search session bills account balance (v2 SigmaBalanceBill)",
-)
+mentor_smoke()
 
 # ---------------------------------------------------------------------------
-# bohrium-sandbox (optional CLI / billable sandbox, skipped)
+# bohrium-sandbox (billable create/exec/kill via lbg sdbx)
 # ---------------------------------------------------------------------------
 print("\n[bohrium-sandbox]")
-skip(
-    "sandbox",
-    "lbg sdbx / open.bohrium.com/openapi/launching/v2/*",
-    "Requires Python >=3.10 and lbg 4.0.0b*; create/exec can be billable",
-)
+sandbox_smoke()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- run bohrium-mentor smoke as a real session create + detail check
- run bohrium-sandbox smoke as real create/exec/kill via lbg sdbx
- update verification report to PASS=16 / FAIL=0 / SKIP=0

## Test
- BOHR_ACCESS_KEY=*** BOHR_SANDBOX_PYTHON=/tmp/bohrium-sdbx-venv/bin/python BOHR_SANDBOX_TEMPLATE=doc-compiler python3 tests/smoke_test.py
- python3 -m py_compile en/bohrium-knowledge-base/scripts/bohrium-kb-upload.py
en/bohrium-knowledge-base/scripts/bohrium_create_kb.py
en/bohrium-project/project_manager.py
en/bohrium-sandbox/sdbx.py
en/bohrium-image/search_images.py
en/bohrium-dataset/dataset_manager.py
en/bohrium-job/poll_jobs.py
en/bohrium-node/node_manager.py
tests/run_all_demos.py
tests/smoke_test.py
en/bohrium-job/batch_submit.py
zh/bohrium-node/node_manager.py
zh/bohrium-job/batch_submit.py
zh/bohrium-job/poll_jobs.py
zh/bohrium-image/search_images.py
zh/bohrium-dataset/dataset_manager.py
zh/bohrium-sandbox/sdbx.py
zh/bohrium-project/project_manager.py
zh/bohrium-knowledge-base/scripts/bohrium-kb-upload.py
zh/bohrium-knowledge-base/scripts/bohrium_create_kb.py