### PR TITLE
bohrium-sciencepedia: 重命名（原 bohrium-wiki）并围绕 4 个用户任务重写

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,9 +29,9 @@
         "./en/bohrium-project",
         "./en/bohrium-sandbox",
         "./en/bohrium-scholar-search",
+        "./en/bohrium-sciencepedia",
         "./en/bohrium-tools",
-        "./en/bohrium-web-search",
-        "./en/bohrium-wiki"
+        "./en/bohrium-web-search"
       ]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ export BOHR_ACCESS_KEY="your_access_key_here"
 | [bohrium-paper-search](zh/bohrium-paper-search/SKILL.md) | 论文与专利搜索 — RAG 引擎关键词+语义检索 |
 | [bohrium-pdf-parser](zh/bohrium-pdf-parser/SKILL.md) | PDF 解析 — 提取文本、表格、图表、公式 |
 | [bohrium-scholar-search](zh/bohrium-scholar-search/SKILL.md) | 学者搜索与画像 — 按姓名/机构检索，查看发文/引用/h-index/研究方向 |
-| [bohrium-wiki](zh/bohrium-wiki/SKILL.md) | 科学百科 — 按层级浏览科学词条 |
+| [bohrium-wiki](zh/bohrium-wiki/SKILL.md) | 科学百科 — 搜词条/关键词拿简介与链接、浏览领域课程、看课程章节知识点、查主题知识图谱 |
 | [bohrium-tools](zh/bohrium-tools/SKILL.md) | 科学工具库 — 按领域/子领域浏览、混合检索工具、查看工具详情与分类 |
 | [bohrium-web-search](zh/bohrium-web-search/SKILL.md) | 网页搜索 — 代理 searchapi.io 做开放互联网检索 |
 | [bohrium-sandbox](zh/bohrium-sandbox/SKILL.md) | 云沙箱 — 按需创建临时云 VM，运行 shell/Python |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ export BOHR_ACCESS_KEY="your_access_key_here"
 | [bohrium-paper-search](zh/bohrium-paper-search/SKILL.md) | 论文与专利搜索 — RAG 引擎关键词+语义检索 |
 | [bohrium-pdf-parser](zh/bohrium-pdf-parser/SKILL.md) | PDF 解析 — 提取文本、表格、图表、公式 |
 | [bohrium-scholar-search](zh/bohrium-scholar-search/SKILL.md) | 学者搜索与画像 — 按姓名/机构检索，查看发文/引用/h-index/研究方向 |
-| [bohrium-wiki](zh/bohrium-wiki/SKILL.md) | 科学百科 — 搜词条/关键词拿简介与链接、浏览领域课程、看课程章节知识点、查主题知识图谱 |
+| [bohrium-sciencepedia](zh/bohrium-sciencepedia/SKILL.md) | 科学百科 — 搜词条/关键词拿简介与链接、浏览领域课程、看课程章节知识点、查主题知识图谱 |
 | [bohrium-tools](zh/bohrium-tools/SKILL.md) | 科学工具库 — 按领域/子领域浏览、混合检索工具、查看工具详情与分类 |
 | [bohrium-web-search](zh/bohrium-web-search/SKILL.md) | 网页搜索 — 代理 searchapi.io 做开放互联网检索 |
 | [bohrium-sandbox](zh/bohrium-sandbox/SKILL.md) | 云沙箱 — 按需创建临时云 VM，运行 shell/Python |

--- a/README_EN.md
+++ b/README_EN.md
@@ -75,7 +75,7 @@ Operate Bohrium platform resources via `bohr` CLI or `open.bohrium.com` HTTP API
 | [bohrium-paper-search](en/bohrium-paper-search/SKILL.md) | Paper & patent search — RAG engine keyword + semantic retrieval |
 | [bohrium-pdf-parser](en/bohrium-pdf-parser/SKILL.md) | PDF parsing — extract text, tables, charts, formulas |
 | [bohrium-scholar-search](en/bohrium-scholar-search/SKILL.md) | Scholar search & profile — find scholars by name/affiliation, view papers/citations/h-index/research directions |
-| [bohrium-wiki](en/bohrium-wiki/SKILL.md) | SciencePedia — browse scientific topics by hierarchy |
+| [bohrium-wiki](en/bohrium-wiki/SKILL.md) | SciencePedia — search topics/keywords for summaries & links, browse fields & courses, get a course's chapters & knowledge points, explore a topic's knowledge graph |
 | [bohrium-tools](en/bohrium-tools/SKILL.md) | Scientific Tools library — browse by domain/subdomain, hybrid-search tools, view tool details & taxonomy |
 | [bohrium-web-search](en/bohrium-web-search/SKILL.md) | Web search — proxy to searchapi.io for open internet search |
 | [bohrium-sandbox](en/bohrium-sandbox/SKILL.md) | Cloud sandbox — on-demand temp VM for running shell/Python |

--- a/README_EN.md
+++ b/README_EN.md
@@ -75,7 +75,7 @@ Operate Bohrium platform resources via `bohr` CLI or `open.bohrium.com` HTTP API
 | [bohrium-paper-search](en/bohrium-paper-search/SKILL.md) | Paper & patent search — RAG engine keyword + semantic retrieval |
 | [bohrium-pdf-parser](en/bohrium-pdf-parser/SKILL.md) | PDF parsing — extract text, tables, charts, formulas |
 | [bohrium-scholar-search](en/bohrium-scholar-search/SKILL.md) | Scholar search & profile — find scholars by name/affiliation, view papers/citations/h-index/research directions |
-| [bohrium-wiki](en/bohrium-wiki/SKILL.md) | SciencePedia — search topics/keywords for summaries & links, browse fields & courses, get a course's chapters & knowledge points, explore a topic's knowledge graph |
+| [bohrium-sciencepedia](en/bohrium-sciencepedia/SKILL.md) | SciencePedia — search topics/keywords for summaries & links, browse fields & courses, get a course's chapters & knowledge points, explore a topic's knowledge graph |
 | [bohrium-tools](en/bohrium-tools/SKILL.md) | Scientific Tools library — browse by domain/subdomain, hybrid-search tools, view tool details & taxonomy |
 | [bohrium-web-search](en/bohrium-web-search/SKILL.md) | Web search — proxy to searchapi.io for open internet search |
 | [bohrium-sandbox](en/bohrium-sandbox/SKILL.md) | Cloud sandbox — on-demand temp VM for running shell/Python |

--- a/en/bohrium-sciencepedia/SKILL.md
+++ b/en/bohrium-sciencepedia/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: bohrium-wiki
+name: bohrium-sciencepedia
 description: "Search and read Bohrium SciencePedia (encyclopedia) via open.bohrium.com. Use when the user wants to: look up / explain a scientific term and get a reading link, browse what disciplines·fields·courses exist, get a course's chapter outline and knowledge list, or explore the knowledge graph around a topic. NOT for: paper search (use bohrium-paper-search), managing your own knowledge base (use bohrium-knowledge-base), or the LKM reasoning graph (use bohrium-lkm)."
 ---
 
@@ -23,7 +23,7 @@ An encyclopedia of scientific concepts. This skill wraps it into **4 things you 
 ## Auth configuration
 
 ```json
-"bohrium-wiki": {
+"bohrium-sciencepedia": {
   "enabled": true,
   "apiKey": "YOUR_BOHR_ACCESS_KEY",
   "env": { "BOHR_ACCESS_KEY": "YOUR_BOHR_ACCESS_KEY" }
@@ -328,5 +328,5 @@ curl -s -G "$BASE/knowledge_graph" \
 
 ## Pairs well with
 
-- **wiki** for a baseline explanation of a concept → **bohrium-paper-search** to go deep
-- **wiki** to browse the discipline tree (`major_levels`) → pick a course → **bohrium-scholar-search** to find leading researchers
+- **bohrium-sciencepedia** for a baseline explanation of a concept → **bohrium-paper-search** to go deep
+- **bohrium-sciencepedia** to browse the discipline tree (`major_levels`) → pick a course → **bohrium-scholar-search** to find leading researchers

--- a/en/bohrium-tools/SKILL.md
+++ b/en/bohrium-tools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bohrium-tools
-description: "Browse and search the Bohrium scientific Tools library via open.bohrium.com. Use when: user wants to browse scientific computing tools by domain/subdomain, hybrid-search tools by keywords, or view a tool's details (GitHub metrics, tutorial, related entries). NOT for: paper search (use bohrium-paper-search), encyclopedia entries (use bohrium-wiki), knowledge base management (use bohrium-knowledge-base)."
+description: "Browse and search the Bohrium scientific Tools library via open.bohrium.com. Use when: user wants to browse scientific computing tools by domain/subdomain, hybrid-search tools by keywords, or view a tool's details (GitHub metrics, tutorial, related entries). NOT for: paper search (use bohrium-paper-search), encyclopedia entries (use bohrium-sciencepedia), knowledge base management (use bohrium-knowledge-base)."
 ---
 
 # SKILL: Bohrium Scientific Tools Library
@@ -20,7 +20,7 @@ Access the **Bohrium Tools library** through the `/v2/literature-sage/tool/*` en
 **Don't use for**:
 
 - Paper search → `bohrium-paper-search`
-- Encyclopedia entries → `bohrium-wiki`
+- Encyclopedia entries → `bohrium-sciencepedia`
 - Managing your own knowledge base → `bohrium-knowledge-base`
 
 **No CLI support** — HTTP API only.

--- a/en/bohrium-wiki/SKILL.md
+++ b/en/bohrium-wiki/SKILL.md
@@ -1,28 +1,24 @@
 ---
 name: bohrium-wiki
-description: "Browse and search Bohrium SciencePedia (encyclopedia) via open.bohrium.com. Use when: user asks about finding scientific topics, reading encyclopedia-style entries, browsing by major/level/field hierarchy, or looking up a specific concept's article. NOT for: paper search (use bohrium-paper-search), knowledge base management (use bohrium-knowledge-base)."
+description: "Search and read Bohrium SciencePedia (encyclopedia) via open.bohrium.com. Use when the user wants to: look up / explain a scientific term and get a reading link, browse what disciplines·fields·courses exist, get a course's chapter outline and knowledge list, or explore the knowledge graph around a topic. NOT for: paper search (use bohrium-paper-search), managing your own knowledge base (use bohrium-knowledge-base), or the LKM reasoning graph (use bohrium-lkm)."
 ---
 
 # SKILL: Bohrium SciencePedia
 
-## Overview
+An encyclopedia of scientific concepts. This skill wraps it into **4 things you can do directly**:
 
-Access **Bohrium SciencePedia** through the `/v2/literature-sage/wiki_v2/*` endpoints on `open.bohrium.com` — a hierarchical encyclopedia of scientific topics organized as `major` → `level` → `field` → `topic` (a `topic` is one article/entry).
+1. **Search a term** → get a summary + a clickable reading link (covers both "topics" and "keywords"; you do **not** need to make the user distinguish them).
+2. **Browse what disciplines, fields and courses exist.**
+3. **Given a course** → get its chapter structure and knowledge-point list.
+4. **Starting from a topic** → get the knowledge graph it forms with related concepts.
 
-> **Two hosts, two jobs**: call the **API** on `open.bohrium.com`; build the **clickable reader link** you show to a human on `https://www.bohrium.com` (see [Building page links](#building-page-links)). They are different hosts — don't paste the API URL to a user.
+> **Two hosts, don't mix them**: call the **API** on `open.bohrium.com`; build the **reading link** you show a human on `https://www.bohrium.com` (see [Building reading links](#building-reading-links)). Never paste the API URL to a user.
 
-**Use when**:
+**Don't use for**: paper search → `bohrium-paper-search`; your own knowledge base → `bohrium-knowledge-base`; LKM reasoning graph → `bohrium-lkm`.
 
-- Getting a quick definition of a scientific term (more focused than web-search — encyclopedia-style entries)
-- Browsing by discipline (e.g., all subfields under materials science)
-- Retrieving the full article of a topic (intro / applications / background sections)
+**No CLI** — HTTP API only.
 
-**Don't use for**:
-
-- Paper search → `bohrium-paper-search`
-- Managing your own knowledge base → `bohrium-knowledge-base`
-
-**No CLI support** — HTTP API only.
+---
 
 ## Auth configuration
 
@@ -30,228 +26,307 @@ Access **Bohrium SciencePedia** through the `/v2/literature-sage/wiki_v2/*` endp
 "bohrium-wiki": {
   "enabled": true,
   "apiKey": "YOUR_BOHR_ACCESS_KEY",
-  "env": {
-    "BOHR_ACCESS_KEY": "YOUR_BOHR_ACCESS_KEY"
-  }
+  "env": { "BOHR_ACCESS_KEY": "YOUR_BOHR_ACCESS_KEY" }
 }
 ```
 
-## Common template
+## Common template (copy-paste)
 
 ```python
 import os, requests
+from urllib.parse import quote
 
 AK = os.environ["BOHR_ACCESS_KEY"]
 BASE = "https://open.bohrium.com/openapi/v2/literature-sage/wiki_v2"
 H = {"Authorization": f"Bearer {AK}", "Content-Type": "application/json"}
 
-# Optional global defaults
+# Almost every endpoint needs these two:
 DEFAULTS = {"language": "en-US", "style": "Feynman"}
-# language: "en-US" / "zh-CN"
-# style: "Feynman" for accessible tone, or others
+# language: "en-US" or "zh-CN"
+# style:    "Feynman" (accessible) or "Hardcore" (rigorous/academic)
+
+def data(resp):
+    """Unwrap: responses are {"code":0,"data":{...}}; errors have code != 0."""
+    resp.raise_for_status()
+    body = resp.json()
+    if body.get("code") not in (0, None):
+        raise RuntimeError(f"API error code={body.get('code')}: {body.get('message') or body}")
+    return body.get("data", body)
 ```
 
----
+## The only 3 concepts you need (ignore the rest of the jargon)
 
-## Actions overview
+| Concept | What it is | What to give the user |
+|---------|------------|-----------------------|
+| **Topic (词条)** | A full encyclopedia article | Build an article link from `entry_id` |
+| **Keyword (关键词)** | A smaller concept card | Build a keyword link from `keyword_id` |
+| **Course / Field (领域)** | A "course" made of many topics | Build a course link from `field_id` |
 
-| Action | Method | Purpose |
-|--------|--------|---------|
-| `info` | GET | Basic SciencePedia info |
-| `major_levels` | POST | List all majors and their levels |
-| `get_wiki_index` | POST | Fetch index for a given nodeId / fieldId |
-| `get_level_wiki_index` | POST | List nodes filtered by `node_types` |
-| `search_index_name` | POST | Keyword search of index entries |
-| `level_fields` | POST | List fields under a set of level nodes |
-| `article` | POST | Fetch the article body of a node / entry |
+> Search returns all three mixed together. **To the user they are just "encyclopedia entries"** — give title + summary + link; no need to explain the type difference.
 
 ---
 
-## Choosing an action (intent → action)
+## Task 1: Search a term, get summaries and reading links
 
-Map what the user is asking for to the right call. Most flows are: **find an id → fetch content**.
-
-| The user wants… | Use | You get back |
-|-----------------|-----|--------------|
-| "What disciplines / majors exist?" (top of the tree) | `major_levels` | majors + their `node_id` and levels |
-| "What fields are under this major/level?" | `level_fields` (bulk, paged) or `get_level_wiki_index` (by `node_types`) | field rows / nodes |
-| "Find the entry or field about **X**" | `search_index_name` | nodes with `node_id`, `node_type`, and `field_id` (for fields) |
-| "Show the outline / topics of this field" | `get_wiki_index` (`field_id` or `node_id`) | topic tree, each topic carries an `entry_id` |
-| "Explain / give me the article on **X**" | `article` (`entry_id` or `node_id`) | `document.article_name` + `main_content` + … |
-| "Is the service up? basic metadata" | `info` | service info |
-
-**Rule of thumb**: if you don't have an id yet, start with `search_index_name`; if the user is browsing a discipline, start with `major_levels`.
-
-## Workflows
-
-### A. Explain a concept (most common)
-
-1. `search_index_name` with `{"name": "<concept>", "node_types": ["field","topic"]}` → take the best match's `node_id` (and `entry_id`/`field_id` if present).
-2. `article` with that id → summarize `document.main_content`.
-3. Return the explanation **plus** the reader link (see [Building page links](#building-page-links)).
-
-### B. Browse a discipline
-
-1. `major_levels` → pick a major/level.
-2. `level_fields` (pass that level's `node_id`) → list fields.
-3. `get_wiki_index` on a `field_id` → list the topics; attach a `course_url` for the field and `article_url` per topic.
-
-### C. Build a learning path for a field
-
-1. Resolve the field via `search_index_name` (`node_types: ["field"]`).
-2. `get_wiki_index` → read topics in tree order.
-3. Present as fundamentals → core → advanced, each topic linked.
-
----
-
-## 1. Info — `info`
+**One endpoint does it**: `POST /search/universal`. It returns related "topics + keywords" (in `articles`) and related "courses" (in `fields`), each with a highlighted snippet.
 
 ```python
-r = requests.get(f"{BASE}/info", headers={"Authorization": f"Bearer {AK}"})
-print(r.json())
+d = data(requests.post(f"{BASE}/search/universal", headers=H,
+                       json={"text": "graphene", **DEFAULTS}))
+
+for a in d["articles"]:                       # topics and keywords mixed, ranked by relevance
+    link = build_read_url(a["type"], a["id"], **DEFAULTS)   # see “Building reading links”
+    snippet = a["matched_elements"][0]["content"] if a.get("matched_elements") else ""
+    print(a["article_name"], "→", link)
+    print("  ", snippet.replace("<em>", "").replace("</em>", ""))   # strip highlight tags
+
+for f in d["fields"]:                         # related courses (optional)
+    print("course:", f["node_name"], "→", course_url(f["field_id"], **DEFAULTS))
 ```
 
----
+Key fields in each `articles[]` item:
+- `type`: `"article"` (topic) or `"keyword"` — **decides which link to build**.
+- `id`: `entry_id` for a topic, `keyword_id` for a keyword.
+- `article_name`: title.
+- `matched_elements[].content`: the matched highlighted snippet, usable as a **summary** (contains `<em>` tags — strip before display).
 
-## 2. Majors & levels — `major_levels`
+### Want a fuller summary / full text
+
+`/search/universal` returns search snippets. For the body, fetch the detail by type:
 
 ```python
-r = requests.post(f"{BASE}/major_levels", headers=H, json={**DEFAULTS})
-for m in r.json().get("majors", []):
-    levels = ", ".join(l["name"] for l in m.get("levels", []))
-    print(f"- {m['name']} [{m['node_id']}]  levels: {levels}")
+# Full topic (article) body
+doc = data(requests.post(f"{BASE}/article", headers=H,
+                         json={"entry_id": "<entry_id>", **DEFAULTS}))["document"]
+
+# Full keyword body
+doc = data(requests.post(f"{BASE}/keyword", headers=H,
+                         json={"keyword_id": "<keyword_id>", **DEFAULTS}))["document"]
+
+# Common fields in doc:
+#   article_name    title
+#   seo_description one-line summary (best for an abstract)
+#   definition      definition
+#   key_points      key points
+#   main_content    body (Markdown)
+#   applications    applications
 ```
+
+> ⚠️ `article` / `keyword` occasionally return `code=250002` (content is generated on demand and not yet available for that language/style). In that case **fall back** to the `matched_elements` snippet from search, or retry with another `style` / `language`.
 
 ---
 
-## 3. Search entries — `search_index_name`
+## Task 2: Browse what fields and courses exist
+
+**Browse by discipline**: get majors and levels first, then list the courses under a level.
 
 ```python
-r = requests.post(f"{BASE}/search_index_name", headers=H, json={
-    "name": "graphene",
-    "node_types": ["field"],   # Filter: major / level / field / topic
-    "style": "Feynman",
-})
-for i, n in enumerate(r.json().get("wiki_indices", []), 1):
-    print(f"[{i}] [{n['node_type']}] {n['node_name']}  id={n['node_id']}")
+# 1) Top structure: major → level
+ml = data(requests.post(f"{BASE}/major_levels", headers=H, json={**DEFAULTS}))
+for m in ml["majors"]:
+    levels = ", ".join(l["name"] for l in m["levels"])
+    print(m["name"], "| levels:", levels)
+
+# 2) List the courses (fields) under some levels
+level_ids = [lv["node_id"] for m in ml["majors"] for lv in m["levels"]]
+lf = data(requests.post(f"{BASE}/level_fields", headers=H,
+                        json={"node_ids": level_ids[:5], "page_num": 1, "page_size": 20, **DEFAULTS}))
+for it in lf["items"]:
+    f = it["field"]
+    print(f'{it["major"]["name"]} / {it["level"]["name"]} / {f["name"]}'
+          f' ({it.get("topic_count", 0)} knowledge points) →', course_url(f["field_id"], **DEFAULTS))
 ```
+
+- `major_levels` returns `majors[]`, each with `name` and `levels[]` (`name` + `node_id`).
+- `level_fields` returns paged `items[]` (`total` = count); each has `major` / `level` / `field`, `topic_count`, and a few sample `topics`; the `field` carries `node_id`, `name`, `seo_title` and **`field_id`**.
+
+> For a clickable **course link**, use `field.field_id` directly (`course_url(...)`, see [Building reading links](#building-reading-links)); for the chapter structure, pass `field_id` (or `field.node_id`) to `get_wiki_index` in Task 3.
 
 ---
 
-## 4. All nodes under a level — `get_level_wiki_index`
+## Task 3: Given a course, get chapters and the knowledge list
+
+Two steps: resolve the course by name → fetch the whole chapter tree.
 
 ```python
-r = requests.post(f"{BASE}/get_level_wiki_index", headers=H, json={
-    "node_types": ["major", "level"],
-    **DEFAULTS,
-})
-for n in r.json().get("wiki_indices", [])[:50]:
-    print(f"[{n['node_type']}] {n['node_name']}  ({n['node_id']})")
+# 1) Locate the course by name (to get field_id)
+s = data(requests.post(f"{BASE}/search/universal", headers=H,
+                       json={"text": "Solid State Physics", **DEFAULTS}))
+field = s["fields"][0]                 # has node_id, field_id, node_name
+
+# 2) Fetch chapter structure + knowledge points (pass field_id, or that field's node_id)
+tree = data(requests.post(f"{BASE}/get_wiki_index", headers=H,
+                          json={"field_id": field["field_id"], **DEFAULTS}))
+
+def walk(nodes, depth=0):
+    for n in nodes:
+        print("  " * depth, f'[{n["node_type"]}]', n["node_name"])
+        if n["node_type"] == "entry":          # leaf = one knowledge point (topic)
+            print("  " * (depth + 1), "→", topic_url(n["entry_id"], **DEFAULTS))
+        walk(n.get("children") or [], depth + 1)
+
+walk(tree["wiki_indices"])
+print("total knowledge points:", tree.get("entry_count"))
 ```
+
+- The tree has 4 levels: `field` (course) → `category` → `chapter` → `entry` (knowledge point / topic).
+- Each node has `node_id`, `node_type`, `node_name`; **leaf `entry` nodes additionally carry `entry_id`** (for the reading link), `snapshot` (an AI quick-look, great as a one-liner), and `seo_title`.
+- The top level also returns `entry_count` plus `foundational_entry_count` / `core_entry_count` / `advanced_entry_count` (foundational / core / advanced counts).
 
 ---
 
-## 5. Index for a given node — `get_wiki_index`
+## Task 4: Starting from a topic, get the knowledge graph
+
+Expand outward from a center node (topic or keyword) to get its graph of related concepts.
 
 ```python
-r = requests.post(f"{BASE}/get_wiki_index", headers=H, json={
-    "node_id": "NODE_ID_HERE",
-    # or "field_id": "FIELD_ID_HERE"
-    **DEFAULTS,
-})
-print(r.json())
+# 1) Find the center node's id (entry_id for a topic, keyword_id for a keyword)
+s = data(requests.post(f"{BASE}/search/universal", headers=H,
+                       json={"text": "superconductivity", **DEFAULTS}))
+center_id = s["articles"][0]["id"]
+# Or find nodes directly with the graph search:
+# gs = data(requests.post(f"{BASE}/knowledge_graph/search", headers=H, json={"text": "entropy"}))
+# center_id = gs["items"][0]["id"]
+
+# 2) Fetch the graph (note: GET + query params)
+g = data(requests.get(f"{BASE}/knowledge_graph", headers=H,
+                      params={"id": center_id, **DEFAULTS}))
+
+for n in g["nodes"]:                  # nodes
+    link = build_read_url(n["node_type"], n["node_id"], **DEFAULTS)
+    print(n["display_name"], f'({n["node_type"]}, depth {n["depth"]})', "→", link)
+
+for e in g["relationships"]:          # edges
+    print(e["src_node_id"], "──", e["relationship"], "──>", e["desc_node_id"],
+          f'(weight {e["weight"]})')
 ```
 
----
+- Input: `id` (required, the center node's `entry_id` or `keyword_id`), `language`, `style`, optional `skip_cross_domain` (true = same-domain only).
+- `nodes[]`: `node_id` (which IS the `entry_id`/`keyword_id`, link it directly), `node_type` (`entry`/`keyword`), `display_name`, `description`, `field_name`, `major_name`, `depth` (center node = 0).
+- `relationships[]`: `src_node_id` / `desc_node_id`, `relationship` (description), `relation_type`, `description`, `weight`, `evidence_count`, `is_bidirectional`, `is_cross_domain`.
+- `domains[]`: disciplines involved (`major_node_id` + `major_name`).
 
-## 6. Bulk list fields under level — `level_fields`
+### Drill into a single node / edge
 
 ```python
-r = requests.post(f"{BASE}/level_fields", headers=H, json={
-    "node_ids": ["LEVEL_NODE_ID1", "LEVEL_NODE_ID2"],
-    "page_num": 1, "page_size": 10,
-    **DEFAULTS,
-})
-for row in r.json().get("items", []):
-    major = row.get("major", {}).get("name")
-    level = row.get("level", {}).get("name")
-    field = row.get("field", {}).get("name")
-    print(f"- {major}/{level}/{field}  topics={row.get('topic_count')}")
+# Single node detail
+node = data(requests.get(f"{BASE}/knowledge_graph/node", headers=H,
+            params={"id": center_id, "node_type": "entry", **DEFAULTS}))
+
+# Single relationship detail (with supporting evidences)
+rel = data(requests.get(f"{BASE}/knowledge_graph/relationship", headers=H,
+           params={"src_node_id": "A", "desc_node_id": "B", "relation_id": "R", **DEFAULTS}))
 ```
 
 ---
 
-## 7. Article body — `article`
+## Action reference
+
+| Task | Method + path | Purpose |
+|------|---------------|---------|
+| Search (preferred) | `POST /search/universal` | One term → topics + keywords + related courses |
+| Topic body | `POST /article` | Article body by `entry_id` (or `node_id`) |
+| Keyword body | `POST /keyword` | Keyword content by `keyword_id` |
+| Discipline tree | `POST /major_levels` | All majors and their levels |
+| Course list | `POST /level_fields` | Courses under some levels (paged) |
+| Course structure | `POST /get_wiki_index` | Chapter tree + knowledge points (leaves carry `entry_id`) |
+| Knowledge graph | `GET /knowledge_graph` | Expand a graph from a topic/keyword |
+| Graph · node | `GET /knowledge_graph/node` | Single node detail |
+| Graph · edge | `GET /knowledge_graph/relationship` | Single relationship detail (with evidence) |
+| Graph · search | `POST /knowledge_graph/search` | Find nodes in the graph by text |
+| (optional) Stats | `GET /info` | Total topics / keywords |
+| (optional) Name search | `POST /search_index_name` | Search nodes by name (e.g. only `field`) |
+
+> Every response is wrapped in `{"code":0,"data":{...}}`; unwrap with `data()` above. `GET` endpoints use `params=`, `POST` endpoints use `json=`.
+
+---
+
+## Building reading links
+
+Whenever you show a topic / keyword / course to a human, attach the reading link on `https://www.bohrium.com` (NOT the API host).
+
+Rules:
+- **Language prefix**: `zh-CN` → no prefix; `en-US` → add `/en`.
+- **Style segment**: lowercase, `Feynman → feynman`, `Hardcore → hardcore`.
+- **URL-encode** dynamic ids.
+
+| Type | Pattern | id source |
+|------|---------|-----------|
+| Topic | `{prefix}/sciencepedia/{style}/{entry_id}` | search `type=article` `id`; course-tree leaf `entry_id`; graph `node_type=entry` `node_id` |
+| Keyword | `{prefix}/sciencepedia/{style}/keyword/{keyword_id}` | search `type=keyword` `id`; graph `node_type=keyword` `node_id` |
+| Course / Field | `{prefix}/sciencepedia/field/{style}/{field_id}` | `/search/universal` `fields[].field_id`, or `/level_fields` `items[].field.field_id` |
 
 ```python
-r = requests.post(f"{BASE}/article", headers=H, json={
-    "node_id": "NODE_ID",         # or "entry_id": "ENTRY_ID"
-    **DEFAULTS,
-})
-doc = r.json().get("document", {})
-print(f"# {doc.get('article_name')}")
-print(doc.get("main_content", "")[:2000])
+def _site(language):
+    return "https://www.bohrium.com/en" if language == "en-US" else "https://www.bohrium.com"
+
+def topic_url(entry_id, language="en-US", style="Feynman"):
+    return f"{_site(language)}/sciencepedia/{style.lower()}/{quote(str(entry_id))}"
+
+def keyword_url(keyword_id, language="en-US", style="Feynman"):
+    return f"{_site(language)}/sciencepedia/{style.lower()}/keyword/{quote(str(keyword_id))}"
+
+def course_url(field_id, language="en-US", style="Feynman"):
+    return f"{_site(language)}/sciencepedia/field/{style.lower()}/{quote(str(field_id))}"
+
+def build_read_url(node_type, node_id, language="en-US", style="Feynman"):
+    # node_type "keyword" -> keyword page; otherwise (article/entry) -> topic page
+    if node_type == "keyword":
+        return keyword_url(node_id, language, style)
+    return topic_url(node_id, language, style)
 ```
 
-**Common fields**: `document.article_name` / `document.main_content` / `document.applications` / `document.seo_title`.
+Examples:
+```text
+Topic   (en, Feynman):   https://www.bohrium.com/en/sciencepedia/feynman/<entry_id>
+Keyword (zh, Feynman):   https://www.bohrium.com/sciencepedia/feynman/keyword/<keyword_id>
+Course  (en, Hardcore):  https://www.bohrium.com/en/sciencepedia/field/hardcore/<field_id>
+```
 
 ---
 
-## curl example
+## curl examples
 
 ```bash
 AK="$BOHR_ACCESS_KEY"
 BASE="https://open.bohrium.com/openapi/v2/literature-sage/wiki_v2"
 
-# Search entries by keyword
-curl -s -X POST "$BASE/search_index_name" \
+# Unified search
+curl -s -X POST "$BASE/search/universal" \
   -H "Authorization: Bearer $AK" -H "Content-Type: application/json" \
-  -d '{"name":"graphene","node_types":["field"],"style":"Feynman"}' \
-  | jq '.wiki_indices[] | {node_name, node_type, node_id}'
+  -d '{"text":"graphene","language":"en-US","style":"Feynman"}' \
+  | jq '.data.articles[] | {type, id, article_name}'
+
+# Knowledge graph (GET + query)
+curl -s -G "$BASE/knowledge_graph" \
+  -H "Authorization: Bearer $AK" \
+  --data-urlencode "id=<entry_id_or_keyword_id>" \
+  --data-urlencode "language=en-US" --data-urlencode "style=Feynman" \
+  | jq '.data | {nodes: (.nodes|length), edges: (.relationships|length)}'
 ```
 
 ---
-
-## Building page links
-
-Whenever you show an entry or field to a human, attach the clickable reader link on `https://www.bohrium.com` (NOT the API host). This is what makes the answer useful to a person.
-
-- **Page host**: `https://www.bohrium.com`
-- **Style segment**: `Feynman → feynman`, `Hardcore → hardcore`
-- **Language prefix**: `zh-CN` → no prefix; `en-US` → prefix with `/en`
-- **URL-encode** dynamic ids.
-
-| Link | Pattern | id source |
-|------|---------|-----------|
-| Article (topic) | `{lang}/sciencepedia/{style}/{entry_id}` | `entry_id` from `get_wiki_index` topic nodes (or the `entry_id` you pass to `article`) |
-| Field (course) | `{lang}/sciencepedia/field/{style}/{field_id}` | `field_id` from `search_index_name` field results / `level_fields` |
-
-```text
-Article (en, Feynman):  https://www.bohrium.com/en/sciencepedia/feynman/<entry_id>
-Field   (zh, Feynman):  https://www.bohrium.com/sciencepedia/field/feynman/solid_state_physics
-```
-
-> This skill exposes only article/field reading — there are no keyword page links here.
 
 ## Response standards
 
-- Prefer a **teaching-style** answer: definition → intuition → key points → where it sits in the tree.
-- Always include the reader link (`article_url` / `course_url`) for any entry or field you mention.
-- If the requested `language`/`style` returns nothing, fall back in order: same language with the other style → `zh-CN`+`Feynman` → `en-US`+`Feynman`, and tell the user you switched.
+- **Search**: just give a list of "title + one-line summary + reading link"; do not explain the "topic vs keyword" difference to the user.
+- **Explain a concept**: definition → intuition → key points, with the entry's reading link.
+- **Course structure**: present as chapter → section → knowledge point, each point linked; you may group by foundational / core / advanced (using `*_entry_count`).
+- **Knowledge graph**: describe the center node first, then list the most relevant edges (by `weight`); expand with `node` / `relationship` detail when needed.
+- Always attach the reading link for any entry you mention. If the requested `language`/`style` returns nothing, fall back in order: same language with the other style → `zh-CN`+`Feynman` → `en-US`+`Feynman`, and say you switched.
 - Keep API failures transparent; on empty results, suggest synonyms and one alternate language/style.
-
----
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `No matches for "..."` | Keyword not in index | Try synonyms; expand `node_types` to `["field","topic","major","level"]` |
-| Empty `article` | Wrong nodeId/entryId or no body | First call `search_index_name` to obtain the correct `node_id` |
-| All-English (or all-Chinese) results | Wrong `language` | Set `"language": "en-US"` or `"zh-CN"` |
-| Built a reader link on `open.bohrium.com` | Mixed up API host and page host | Page links use `https://www.bohrium.com` (see *Building page links*) |
+| No matches | Term not in the index | Try synonyms; or use `/search_index_name` with broader `node_types` |
+| `article`/`keyword` returns `250002` | Content not yet generated for that language/style | Fall back to the search snippet, or retry with another `style`/`language` |
+| All-English (or all-Chinese) results | Wrong `language` | Set `"language":"en-US"` or `"zh-CN"` |
+| Empty knowledge graph | `id` is not a valid `entry_id`/`keyword_id`, or the node has no neighbors | First resolve the id via `/search/universal` or `/knowledge_graph/search` |
+| Built a reading link on `open.bohrium.com` | Mixed up API host and page host | Page links use `https://www.bohrium.com` (see [Building reading links](#building-reading-links)) |
 
 ## Pairs well with
 
-- **wiki** for a baseline explanation of a concept → **paper-search** to go deep
-- **wiki** to browse the discipline tree (`major_levels`) → pick a field → **scholar** to find leading researchers
+- **wiki** for a baseline explanation of a concept → **bohrium-paper-search** to go deep
+- **wiki** to browse the discipline tree (`major_levels`) → pick a course → **bohrium-scholar-search** to find leading researchers

--- a/tests/VERIFICATION_REPORT.md
+++ b/tests/VERIFICATION_REPORT.md
@@ -1,6 +1,6 @@
 # Bohrium Skills API 端点验证报告
 
-**最近验证**: 2026-06-15（全量真实冒烟，含 mentor/sandbox）｜2026-06-11（bohrium-tools 真实实测）｜2026-06-08（v2 网关冒烟实测）｜详细功能基线: 2026-05-11
+**最近验证**: 2026-06-26（bohrium-wiki 重写后 12 端点真实实测）｜2026-06-15（全量真实冒烟，含 mentor/sandbox）｜2026-06-11（bohrium-tools 真实实测）｜2026-06-08（v2 网关冒烟实测）｜详细功能基线: 2026-05-11
 **测试 AK**: 通过 `BOHR_ACCESS_KEY` 环境变量注入（不在报告中明文记录）
 **API Base**: https://open.bohrium.com/openapi/v2 （网关已升级 v2；`bohrium-job` 仍用 v1）
 **bohr CLI**: v1.1.0 (Go, 从 OSS 安装到 ~/.bohrium/bohr)
@@ -242,18 +242,27 @@
 
 ---
 
-### bohrium-wiki (百科)
+### bohrium-wiki (百科) — 2026-06-26 真实实测（重写后 12 端点全通）
 
 > 网关前缀 `/openapi/v2/literature-sage/wiki_v2/*` → LiteratureSage `/api/v1/wiki_v2`。
+> 重写后 skill 围绕 4 个用户任务（搜词条/关键词、浏览领域课程、看课程章节、查知识图谱）。下表为 2026-06-26 用真实数据按调用链跑的冒烟（`/tmp/wiki_smoke.py`），全部 HTTP=200 / `code=0`。
 
-| 端点 | 方法 | 状态 | 备注 |
+| 端点 | 方法 | 状态 | 实测要点（`data` 下） |
 |------|------|------|------|
-| `/v2/literature-sage/wiki_v2/info` | GET | ✅ | 基础信息 |
-| `/v2/literature-sage/wiki_v2/search_index_name` | POST | ✅ | 中英文搜索均正常（冒烟实测 PASS） |
-| `/v2/literature-sage/wiki_v2/major_levels` | POST | ✅ | 学科分类 |
-| `/v2/literature-sage/wiki_v2/article` | POST | ⚠️ | 250002 "Article not found"（内容可能按需生成） |
+| `/wiki_v2/search/universal` | POST | ✅ | `articles[]`（`type`=article/keyword、`id`、`article_name`、`matched_elements`）+ `fields[]`（带 `field_id`/`node_id`，命中需用课程名查询） |
+| `/wiki_v2/article` | POST | ✅ | `document` 全文：`article_name`/`main_content`/`seo_description`/`field_node.field_id` 等（用 `entry_id` 取，如 `many_body_physics-physics_of_graphene`） |
+| `/wiki_v2/keyword` | POST | ✅ | `document`：`definition`/`applications`/`appendices`/`citations`/`current_revision_id` 等（用 `keyword_id` 取） |
+| `/wiki_v2/major_levels` | POST | ✅ | `majors[]`（9 大类 / 17 分级），每级带 `node_id` |
+| `/wiki_v2/level_fields` | POST | ✅ | 分页 `items[]`（`total`），`field` 对象含 `field_id`/`node_id`/`name`/`seo_title`、`topic_count`、示例 `topics` |
+| `/wiki_v2/get_wiki_index` | POST | ✅ | 课程章节树 `wiki_indices` + `entry_count`/基础·核心·进阶计数；叶子 `entry` 带 `entry_id`/`snapshot`/`seo_description` |
+| `/wiki_v2/knowledge_graph` | GET | ✅ | 从中心 `id` 展开：`nodes`(577)/`relationships`(999)/`domains`(8)，节点带 `node_type`/`field_id`/`depth` 等 |
+| `/wiki_v2/knowledge_graph/search` | POST | ✅ | `items[]`（`type`=entry/keyword、`id`）用于拿图谱中心点 |
+| `/wiki_v2/knowledge_graph/node` | GET | ✅ | 单节点详情（`display_name`/`description`/`field_name` 等） |
+| `/wiki_v2/knowledge_graph/relationship` | GET | ✅ | 边详情，含 `evidences`（小写）/`evidence_count`/`is_cross_domain` |
+| `/wiki_v2/info` | GET | ✅ | 总量：entry 47467 / keyword 108719 / total 156186 |
+| `/wiki_v2/search_index_name` | POST | ✅ | 按名搜索索引（`node_types` 过滤；非课程名词可能 0 命中属正常） |
 
-**结论**: 索引搜索正常；article 端点可达。
+**结论**: 重写后 4 个用户任务覆盖的 12 个端点全部实测通过。`article`/`keyword` 用正确的 `entry_id`/`keyword_id` 可正常取全文（早先 250002 是该 id 无内容的个例，非接口问题）。修正点：`level_fields` 的 `field` 对象**确实返回 `field_id`**（Apifox 示例漏录），课程链接可直接用它拼。知识图谱为 **GET + 单个 `id`**（非 Apifox 标的 POST+ids）。
 
 ---
 
@@ -328,7 +337,7 @@
 | 1 | bohrium-job | API `POST /job/submit`、`GET /job_group/list` 返回 404 | 不影响 | CLI 正常，文档已说明优先 CLI |
 | 2 | bohrium-node | API `/node/start/{id}` 返回 404 | 低 | 文档使用 `restart`；start 网关无路由 |
 | 3 | ~~bohrium-dataset~~ | ~~`open.bohrium.com` 的 `POST /ds/` 307→404~~ | ~~中~~ | **已修复**：307 已修复，统一 open.bohrium.com |
-| 4 | bohrium-wiki | article 端点返回 250002 "Article not found" | 低 | 索引存在，文章内容按需生成 |
+| 4 | ~~bohrium-wiki~~ | ~~article 端点返回 250002 "Article not found"~~ | ~~低~~ | **已澄清**：用正确 `entry_id` 可正常取全文（2026-06-26 实测）；250002 仅为无内容个例 |
 | 5 | bohrium-lkm | `/papers/ocr/batch` 返回 290007 权限不足 | 低 | 需更高权限 AK |
 
 ## CLI 环境配置说明

--- a/tests/VERIFICATION_REPORT.md
+++ b/tests/VERIFICATION_REPORT.md
@@ -1,6 +1,6 @@
 # Bohrium Skills API 端点验证报告
 
-**最近验证**: 2026-06-26（bohrium-wiki 重写后 12 端点真实实测）｜2026-06-15（全量真实冒烟，含 mentor/sandbox）｜2026-06-11（bohrium-tools 真实实测）｜2026-06-08（v2 网关冒烟实测）｜详细功能基线: 2026-05-11
+**最近验证**: 2026-06-26（bohrium-sciencepedia 重写后 12 端点真实实测，原 bohrium-wiki 重命名）｜2026-06-15（全量真实冒烟，含 mentor/sandbox）｜2026-06-11（bohrium-tools 真实实测）｜2026-06-08（v2 网关冒烟实测）｜详细功能基线: 2026-05-11
 **测试 AK**: 通过 `BOHR_ACCESS_KEY` 环境变量注入（不在报告中明文记录）
 **API Base**: https://open.bohrium.com/openapi/v2 （网关已升级 v2；`bohrium-job` 仍用 v1）
 **bohr CLI**: v1.1.0 (Go, 从 OSS 安装到 ~/.bohrium/bohr)
@@ -28,7 +28,7 @@
 | bohrium-pdf-parser | `/v2/parse/trigger-url-async` | POST | ✅ PASS | 按页余额扣费 |
 | bohrium-web-search | `/v2/search/web` | GET | ✅ PASS | 免费（v2 取消 v1 限额） |
 | bohrium-scholar-search | `/v2/paper-server/scholar/search` | POST | ✅ PASS | 免费 |
-| bohrium-wiki | `/v2/literature-sage/wiki_v2/search_index_name` | POST | ✅ PASS | 免费 |
+| bohrium-sciencepedia | `/v2/literature-sage/wiki_v2/search_index_name` | POST | ✅ PASS | 免费 |
 | bohrium-tools | `/v2/literature-sage/tool/domain` | GET | ✅ PASS | 免费 |
 | bohrium-tools | `/v2/literature-sage/tool/search/hybrid` | POST | ✅ PASS | 免费 |
 | bohrium-mentor | `/v2/sigma-search/api/v4/ai_search/sessions` | POST | ✅ PASS | 创建会话扣余额 |
@@ -42,7 +42,7 @@
 
 | 状态 | Skill | 说明 |
 |------|-------|------|
-| ✅ 完全可用 | bohrium-project, bohrium-pdf-parser, bohrium-web-search, bohrium-sandbox, bohrium-job, bohrium-node, bohrium-knowledge-base, bohrium-image, bohrium-scholar-search, bohrium-wiki, bohrium-tools, bohrium-lkm, bohrium-paper-search, bohrium-dataset, bohrium-mentor | 当前仓库 15 个 skill，文档端点 / CLI 均正常 |
+| ✅ 完全可用 | bohrium-project, bohrium-pdf-parser, bohrium-web-search, bohrium-sandbox, bohrium-job, bohrium-node, bohrium-knowledge-base, bohrium-image, bohrium-scholar-search, bohrium-sciencepedia, bohrium-tools, bohrium-lkm, bohrium-paper-search, bohrium-dataset, bohrium-mentor | 当前仓库 15 个 skill，文档端点 / CLI 均正常 |
 | ❌ 已移除 | polymer-db, bohrium-file, bohrium-viking-memory, bohrium-scholar, bohrium-matmaster, diagnose-agent, proposal-agent, preparation-agent, scoring-agent | 已下架 / 冗余 / 后端不可用；当前仓库不含这些 skill |
 
 ---
@@ -242,7 +242,7 @@
 
 ---
 
-### bohrium-wiki (百科) — 2026-06-26 真实实测（重写后 12 端点全通）
+### bohrium-sciencepedia (百科，原 bohrium-wiki) — 2026-06-26 真实实测（重写后 12 端点全通）
 
 > 网关前缀 `/openapi/v2/literature-sage/wiki_v2/*` → LiteratureSage `/api/v1/wiki_v2`。
 > 重写后 skill 围绕 4 个用户任务（搜词条/关键词、浏览领域课程、看课程章节、查知识图谱）。下表为 2026-06-26 用真实数据按调用链跑的冒烟（`/tmp/wiki_smoke.py`），全部 HTTP=200 / `code=0`。
@@ -337,7 +337,7 @@
 | 1 | bohrium-job | API `POST /job/submit`、`GET /job_group/list` 返回 404 | 不影响 | CLI 正常，文档已说明优先 CLI |
 | 2 | bohrium-node | API `/node/start/{id}` 返回 404 | 低 | 文档使用 `restart`；start 网关无路由 |
 | 3 | ~~bohrium-dataset~~ | ~~`open.bohrium.com` 的 `POST /ds/` 307→404~~ | ~~中~~ | **已修复**：307 已修复，统一 open.bohrium.com |
-| 4 | ~~bohrium-wiki~~ | ~~article 端点返回 250002 "Article not found"~~ | ~~低~~ | **已澄清**：用正确 `entry_id` 可正常取全文（2026-06-26 实测）；250002 仅为无内容个例 |
+| 4 | ~~bohrium-sciencepedia~~ | ~~article 端点返回 250002 "Article not found"~~ | ~~低~~ | **已澄清**：用正确 `entry_id` 可正常取全文（2026-06-26 实测）；250002 仅为无内容个例 |
 | 5 | bohrium-lkm | `/papers/ocr/batch` 返回 290007 权限不足 | 低 | 需更高权限 AK |
 
 ## CLI 环境配置说明

--- a/tests/VERIFICATION_REPORT.md
+++ b/tests/VERIFICATION_REPORT.md
@@ -29,7 +29,7 @@
 | bohrium-pdf-parser | `/v2/parse/trigger-url-async` | POST | ✅ PASS | 按页余额扣费 |
 | bohrium-web-search | `/v2/search/web` | GET | ✅ PASS | 免费（v2 取消 v1 限额） |
 | bohrium-scholar-search | `/v2/paper-server/scholar/search` | POST | ✅ PASS | 免费 |
-| bohrium-sciencepedia | `/v2/literature-sage/wiki_v2/search_index_name` | POST | ✅ PASS | 免费 |
+| bohrium-sciencepedia | `/wiki_v2/{info, search/universal, article, major_levels, level_fields, get_wiki_index, knowledge_graph, search_index_name}` | GET / POST | ✅ PASS ×8（任务链路冒烟） | 免费 |
 | bohrium-tools | `/v2/literature-sage/tool/domain` | GET | ✅ PASS | 免费 |
 | bohrium-tools | `/v2/literature-sage/tool/search/hybrid` | POST | ✅ PASS | 免费 |
 | bohrium-mentor | `/v2/sigma-search/api/v4/ai_search/sessions` | POST | ✅ PASS | 创建会话扣余额 |
@@ -275,7 +275,7 @@
 ### bohrium-sciencepedia (百科，原 bohrium-wiki) — 2026-06-26 真实实测（重写后 12 端点全通）
 
 > 网关前缀 `/openapi/v2/literature-sage/wiki_v2/*` → LiteratureSage `/api/v1/wiki_v2`。
-> 重写后 skill 围绕 4 个用户任务（搜词条/关键词、浏览领域课程、看课程章节、查知识图谱）。下表为 2026-06-26 用真实数据按调用链跑的冒烟（`/tmp/wiki_smoke.py`），全部 HTTP=200 / `code=0`。
+> 重写后 skill 围绕 4 个用户任务（搜词条/关键词、浏览领域课程、看课程章节、查知识图谱）。下表为 2026-06-26 用真实数据按调用链跑的冒烟，全部 HTTP=200 / `code=0`。其中 8 个核心免费端点（`/info`、`/search/universal`、`/article`、`/major_levels`、`/level_fields`、`/get_wiki_index`、`/knowledge_graph`、`/search_index_name`）已纳入仓库内 `tests/smoke_test.py` 的 `sciencepedia_smoke()` 链路（用前一步真实响应里的 id 串起来，不依赖硬编码）；图谱细节（`/knowledge_graph/node`、`/relationship`、`/search`）及 `/keyword` 暂以本表实测覆盖。
 
 | 端点 | 方法 | 状态 | 实测要点（`data` 下） |
 |------|------|------|------|

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -446,11 +446,11 @@ record(
 )
 
 # ---------------------------------------------------------------------------
-# bohrium-wiki
+# bohrium-sciencepedia (formerly bohrium-wiki)
 # ---------------------------------------------------------------------------
-print("\n[bohrium-wiki]")
+print("\n[bohrium-sciencepedia]")
 record(
-    "wiki",
+    "sciencepedia",
     "/v2/literature-sage/wiki_v2/search_index_name",
     "POST",
     body={"name": "graphene", "node_types": ["field"], "style": "Feynman"},

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -513,14 +513,131 @@ record(
 
 # ---------------------------------------------------------------------------
 # bohrium-sciencepedia (formerly bohrium-wiki)
+#
+# Chains through the four documented user tasks (search / browse / course
+# structure / knowledge graph) using ids resolved from previous responses, so a
+# doc–gateway drift on any of those endpoints surfaces immediately. All paths
+# touched here are free / read-only.
 # ---------------------------------------------------------------------------
 print("\n[bohrium-sciencepedia]")
-record(
-    "sciencepedia",
-    "/v2/literature-sage/wiki_v2/search_index_name",
-    "POST",
-    body={"name": "graphene", "node_types": ["field"], "style": "Feynman"},
-)
+
+
+def sciencepedia_smoke() -> None:
+    wiki_base = "/v2/literature-sage/wiki_v2"
+    defaults = {"language": "en-US", "style": "Feynman"}
+
+    def push(skill: str, endpoint: str, method: str, code: int, status: str, note: str) -> None:
+        results.append(Result(skill, endpoint, status, code, note))
+        print(f"  [{status}] {method:<4} {endpoint}  HTTP={code}  {note}")
+
+    # 0) /info — service stats (no body, no auth params beyond bearer).
+    record("sciencepedia", f"{wiki_base}/info", "GET")
+
+    # 1) /search/universal — unified search; capture an article id + field id.
+    search_endpoint = f"{wiki_base}/search/universal"
+    code, data = http("POST", search_endpoint, body={"text": "graphene", **defaults})
+    status, note = classify(code, data)
+    entry_id: str | None = None
+    field_id: str | None = None
+    if status == "PASS":
+        payload = data.get("data") if isinstance(data, dict) else None
+        articles = (payload or {}).get("articles") or []
+        fields = (payload or {}).get("fields") or []
+        for a in articles:
+            if a.get("type") == "article" and a.get("id"):
+                entry_id = a["id"]
+                break
+        for f in fields:
+            if f.get("field_id"):
+                field_id = f["field_id"]
+                break
+        note = f"articles={len(articles)} fields={len(fields)}"
+    push("sciencepedia", search_endpoint, "POST", code, status, note)
+
+    # 1') /article — fetch full body for the article id from search.
+    article_endpoint = f"{wiki_base}/article"
+    if entry_id:
+        code, data = http("POST", article_endpoint, body={"entry_id": entry_id, **defaults})
+        status, note = classify(code, data)
+        # 250002 = "content not yet generated for this language/style" — documented
+        # fallback path, not a regression of the endpoint itself.
+        api_code = data.get("code") if isinstance(data, dict) else None
+        if status == "FAIL" and api_code == 250002:
+            status = "PASS"
+            note = f"tolerated api code=250002 (content not generated for entry_id={entry_id[:24]})"
+        elif status == "PASS":
+            note = f"entry_id={entry_id[:24]}"
+        push("sciencepedia", article_endpoint, "POST", code, status, note)
+    else:
+        skip("sciencepedia", article_endpoint, "no entry_id from /search/universal")
+
+    # 2) /major_levels — discipline tree; collect a few level_ids for /level_fields.
+    ml_endpoint = f"{wiki_base}/major_levels"
+    code, data = http("POST", ml_endpoint, body=defaults)
+    status, note = classify(code, data)
+    level_ids: list[str] = []
+    if status == "PASS":
+        majors = ((data.get("data") if isinstance(data, dict) else None) or {}).get("majors") or []
+        for m in majors:
+            for lv in m.get("levels") or []:
+                if lv.get("node_id"):
+                    level_ids.append(lv["node_id"])
+        note = f"majors={len(majors)} levels={len(level_ids)}"
+    push("sciencepedia", ml_endpoint, "POST", code, status, note)
+
+    # 2') /level_fields — paged courses under those level ids.
+    lf_endpoint = f"{wiki_base}/level_fields"
+    if level_ids:
+        record(
+            "sciencepedia",
+            lf_endpoint,
+            "POST",
+            body={
+                "node_ids": level_ids[:3],
+                "page_num": 1,
+                "page_size": 5,
+                **defaults,
+            },
+        )
+    else:
+        skip("sciencepedia", lf_endpoint, "no level_ids from /major_levels")
+
+    # 3) /get_wiki_index — chapter tree for the course found in search.
+    gwi_endpoint = f"{wiki_base}/get_wiki_index"
+    if field_id:
+        record(
+            "sciencepedia",
+            gwi_endpoint,
+            "POST",
+            body={"field_id": field_id, **defaults},
+            note_on_pass=f"field_id={field_id[:24]}",
+        )
+    else:
+        skip("sciencepedia", gwi_endpoint, "no field_id from /search/universal")
+
+    # 4) /knowledge_graph — GET, single id (the entry from task 1).
+    kg_endpoint = f"{wiki_base}/knowledge_graph"
+    if entry_id:
+        record(
+            "sciencepedia",
+            kg_endpoint,
+            "GET",
+            params={"id": entry_id, **defaults},
+            note_on_pass=f"id={entry_id[:24]}",
+        )
+    else:
+        skip("sciencepedia", kg_endpoint, "no entry_id from /search/universal")
+
+    # Backward-compat: original single-endpoint smoke kept for regression.
+    record(
+        "sciencepedia",
+        f"{wiki_base}/search_index_name",
+        "POST",
+        body={"name": "graphene", "node_types": ["field"], "style": "Feynman"},
+    )
+
+
+sciencepedia_smoke()
 
 # ---------------------------------------------------------------------------
 # bohrium-tools  (literature-sage tool library — list/search are free)

--- a/zh/bohrium-sciencepedia/SKILL.md
+++ b/zh/bohrium-sciencepedia/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: bohrium-wiki
+name: bohrium-sciencepedia
 description: "Search and read Bohrium SciencePedia (科学百科) via open.bohrium.com. Use when the user wants to: look up / explain a scientific term and get a reading link (搜词条/关键词), browse what disciplines·fields·courses exist (有哪些领域和课程), get a course's chapter outline and knowledge list (课程章节与知识点), or explore the knowledge graph around a topic (主题相关的知识图谱). NOT for: paper search (use bohrium-paper-search), managing your own knowledge base (use bohrium-knowledge-base), or the LKM reasoning graph (use bohrium-lkm)."
 ---
 
@@ -23,7 +23,7 @@ description: "Search and read Bohrium SciencePedia (科学百科) via open.bohri
 ## 认证配置
 
 ```json
-"bohrium-wiki": {
+"bohrium-sciencepedia": {
   "enabled": true,
   "apiKey": "YOUR_BOHR_ACCESS_KEY",
   "env": { "BOHR_ACCESS_KEY": "YOUR_BOHR_ACCESS_KEY" }
@@ -328,5 +328,5 @@ curl -s -G "$BASE/knowledge_graph" \
 
 ## 搭配使用
 
-- **wiki** 拿概念的基础解释 → **bohrium-paper-search** 深入某个方向
-- **wiki** 浏览学科目录（`major_levels`）→ 选定课程 → **bohrium-scholar-search** 找代表学者
+- **bohrium-sciencepedia** 拿概念的基础解释 → **bohrium-paper-search** 深入某个方向
+- **bohrium-sciencepedia** 浏览学科目录（`major_levels`）→ 选定课程 → **bohrium-scholar-search** 找代表学者

--- a/zh/bohrium-tools/SKILL.md
+++ b/zh/bohrium-tools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bohrium-tools
-description: "浏览与检索 Bohrium 科学工具库（Tools），通过 open.bohrium.com 访问。Use when: 用户需要按领域/子领域浏览科学计算工具、按关键词混合检索工具、查看某个工具的详情（GitHub 指标、教程、关联词条等）。NOT for: 论文检索（用 bohrium-paper-search）、百科词条（用 bohrium-wiki）、知识库管理（用 bohrium-knowledge-base）。"
+description: "浏览与检索 Bohrium 科学工具库（Tools），通过 open.bohrium.com 访问。Use when: 用户需要按领域/子领域浏览科学计算工具、按关键词混合检索工具、查看某个工具的详情（GitHub 指标、教程、关联词条等）。NOT for: 论文检索（用 bohrium-paper-search）、百科词条（用 bohrium-sciencepedia）、知识库管理（用 bohrium-knowledge-base）。"
 ---
 
 # SKILL: Bohrium 科学工具库（Tools）
@@ -20,7 +20,7 @@ description: "浏览与检索 Bohrium 科学工具库（Tools），通过 open.b
 **不适用**：
 
 - 搜论文 → `bohrium-paper-search`
-- 查百科词条 → `bohrium-wiki`
+- 查百科词条 → `bohrium-sciencepedia`
 - 管理自己的知识库 → `bohrium-knowledge-base`
 
 **无 CLI 支持** — 通过 HTTP API 操作。

--- a/zh/bohrium-wiki/SKILL.md
+++ b/zh/bohrium-wiki/SKILL.md
@@ -1,28 +1,24 @@
 ---
 name: bohrium-wiki
-description: "Browse and search Bohrium SciencePedia (百科) via open.bohrium.com. Use when: user asks about finding scientific topics, reading encyclopedia-style entries, browsing by major/level/field hierarchy, or looking up a specific concept's article. NOT for: paper search (use bohrium-paper-search), knowledge base management (use bohrium-knowledge-base)."
+description: "Search and read Bohrium SciencePedia (科学百科) via open.bohrium.com. Use when the user wants to: look up / explain a scientific term and get a reading link (搜词条/关键词), browse what disciplines·fields·courses exist (有哪些领域和课程), get a course's chapter outline and knowledge list (课程章节与知识点), or explore the knowledge graph around a topic (主题相关的知识图谱). NOT for: paper search (use bohrium-paper-search), managing your own knowledge base (use bohrium-knowledge-base), or the LKM reasoning graph (use bohrium-lkm)."
 ---
 
-# SKILL: Bohrium SciencePedia (百科)
+# SKILL: Bohrium 科学百科（SciencePedia）
 
-## 概述
+一个面向科学概念的百科。这个 skill 把它包装成 **4 件你能直接做的事**：
 
-通过 `open.bohrium.com` 的 `/v2/literature-sage/wiki_v2/*` 端点访问 **Bohrium 百科**——一个科学主题的百科索引，按 `major` (大类) → `level` (分级) → `field` (领域) → `topic` (词条) 层级组织（一个 `topic` 即一篇文章/词条）。
+1. **搜一个词** → 拿到简介 + 可点击的阅读链接（自动覆盖「词条」和「关键词」，你**不用**向用户区分二者）。
+2. **看百科里有哪些领域和课程**（按学科浏览）。
+3. **给定一个课程** → 拿到它的章节结构和知识点列表。
+4. **从一个主题出发** → 拿到它和相关概念组成的知识图谱。
 
-> **两个 Host，各司其职**：调用 **API** 用 `open.bohrium.com`；给人看的**可点击阅读链接**用 `https://www.bohrium.com`（见[构造页面链接](#构造页面链接)）。二者是不同的 Host——不要把 API URL 直接发给用户。
+> **两个 Host，别混用**：调 **API** 用 `open.bohrium.com`；给人看的**阅读链接**用 `https://www.bohrium.com`（见[拼阅读链接](#拼阅读链接)）。不要把 API 地址发给用户。
 
-**典型场景**：
+**不适用**：搜论文 → `bohrium-paper-search`；管理自己的知识库 → `bohrium-knowledge-base`；大知识模型推理图谱 → `bohrium-lkm`。
 
-- 快速了解某个科学名词的定义（比 web-search 更聚焦于"百科条目"）
-- 按学科分类浏览（如材料科学下面的所有子领域）
-- 查询词条的正文（简介 / 应用 / 背景等段落）
+**无 CLI** — 全部通过 HTTP API。
 
-**不适用**：
-
-- 搜论文 → `bohrium-paper-search`
-- 管理自己的知识库 → `bohrium-knowledge-base`
-
-**无 CLI 支持** — 通过 HTTP API 操作。
+---
 
 ## 认证配置
 
@@ -30,170 +26,262 @@ description: "Browse and search Bohrium SciencePedia (百科) via open.bohrium.c
 "bohrium-wiki": {
   "enabled": true,
   "apiKey": "YOUR_BOHR_ACCESS_KEY",
-  "env": {
-    "BOHR_ACCESS_KEY": "YOUR_BOHR_ACCESS_KEY"
-  }
+  "env": { "BOHR_ACCESS_KEY": "YOUR_BOHR_ACCESS_KEY" }
 }
 ```
 
-## 通用代码模板
+## 通用模板（复制即用）
 
 ```python
 import os, requests
+from urllib.parse import quote
 
 AK = os.environ["BOHR_ACCESS_KEY"]
 BASE = "https://open.bohrium.com/openapi/v2/literature-sage/wiki_v2"
 H = {"Authorization": f"Bearer {AK}", "Content-Type": "application/json"}
 
-# 可选的全局默认参数
+# 几乎所有接口都要带这两个参数：
 DEFAULTS = {"language": "en-US", "style": "Feynman"}
-# language: "en-US" / "zh-CN"
-# style: "Feynman" 风格通俗，或其他风格
+# language: "en-US" 或 "zh-CN"
+# style:    "Feynman"（通俗易懂）或 "Hardcore"（硬核学术）
+
+def data(resp):
+    """统一解包：响应是 {"code":0,"data":{...}}，错误时 code!=0。"""
+    resp.raise_for_status()
+    body = resp.json()
+    if body.get("code") not in (0, None):
+        raise RuntimeError(f"API error code={body.get('code')}: {body.get('message') or body}")
+    return body.get("data", body)
 ```
 
----
+## 三个最少必要的概念（其余 jargon 都可忽略）
 
-## Action 概览
+| 概念 | 是什么 | 怎么给用户 |
+|------|--------|-----------|
+| **词条 / 主题（topic）** | 一篇完整的百科文章 | 用 `entry_id` 拼文章链接 |
+| **关键词（keyword）** | 一个更小的概念卡片 | 用 `keyword_id` 拼关键词链接 |
+| **课程 / 领域（field）** | 一组词条组成的「课」 | 用 `field_id` 拼课程链接 |
 
-| Action | 方法 | 用途 |
-|--------|------|------|
-| `info` | GET | 获取 SciencePedia 基础信息 |
-| `major_levels` | POST | 列出所有大类及其分级 |
-| `get_wiki_index` | POST | 给定 nodeId 或 fieldId，获取索引 |
-| `get_level_wiki_index` | POST | 列出指定 `node_types` 下的所有节点 |
-| `search_index_name` | POST | 按关键词搜索词条索引 |
-| `level_fields` | POST | 在一组 level 节点下列出领域 |
-| `article` | POST | 获取某个节点/词条的正文 |
+> 搜索时这三者会混在一起返回。**对用户而言它们都是「百科条目」**——直接给标题 + 简介 + 链接即可，不必解释类型差异。
 
 ---
 
-## 如何选择 Action（意图 → Action）
+## 任务 1：搜一个词，拿简介和阅读链接
 
-把用户的诉求映射到正确的调用。大多数流程都是：**先拿到 id → 再取内容**。
-
-| 用户想要…… | 用 | 拿到 |
-|-----------|----|------|
-| “有哪些学科 / 大类？”（树的顶层） | `major_levels` | 大类及其 `node_id`、分级 |
-| “某大类/分级下有哪些领域？” | `level_fields`（批量分页）或 `get_level_wiki_index`（按 `node_types`） | 领域行 / 节点 |
-| “找关于 **X** 的词条或领域” | `search_index_name` | 含 `node_id`、`node_type`，领域节点带 `field_id` |
-| “这个领域的大纲 / 有哪些词条？” | `get_wiki_index`（`field_id` 或 `node_id`） | 词条树，每个词条带 `entry_id` |
-| “解释 / 给我 **X** 的正文” | `article`（`entry_id` 或 `node_id`） | `document.article_name` + `main_content` + …… |
-| “服务是否可用 / 基础信息” | `info` | 服务信息 |
-
-**经验法则**：还没有 id 就先用 `search_index_name`；用户在浏览学科则从 `major_levels` 开始。
-
-## 工作流
-
-### A. 解释一个概念（最常见）
-
-1. `search_index_name`，传 `{"name": "<概念>", "node_types": ["field","topic"]}` → 取最佳命中的 `node_id`（如有 `entry_id`/`field_id` 一并记下）。
-2. `article` 传该 id → 概括 `document.main_content`。
-3. 返回解释 **并附上**阅读链接（见[构造页面链接](#构造页面链接)）。
-
-### B. 浏览一个学科
-
-1. `major_levels` → 选定大类/分级。
-2. `level_fields`（传该 level 的 `node_id`）→ 列出领域。
-3. `get_wiki_index` 传 `field_id` → 列出词条；为领域附 `course_url`，为每个词条附 `article_url`。
-
-### C. 为某领域规划学习路径
-
-1. 用 `search_index_name`（`node_types: ["field"]`）定位领域。
-2. `get_wiki_index` → 按树顺序读取词条。
-3. 以 基础 → 核心 → 进阶 呈现，每个词条都带链接。
-
----
-
-## 1. 基础信息 — `info`
+**首选一个接口搞定**：`POST /search/universal`。它一次返回相关的「词条 + 关键词」（在 `articles` 里）和相关「课程」（在 `fields` 里），每条都带高亮简介。
 
 ```python
-r = requests.get(f"{BASE}/info", headers={"Authorization": f"Bearer {AK}"})
-print(r.json())
+d = data(requests.post(f"{BASE}/search/universal", headers=H,
+                       json={"text": "graphene", **DEFAULTS}))
+
+for a in d["articles"]:                       # 词条与关键词混合，按相关度排好序
+    link = build_read_url(a["type"], a["id"], **DEFAULTS)   # 见“拼阅读链接”
+    snippet = a["matched_elements"][0]["content"] if a.get("matched_elements") else ""
+    print(a["article_name"], "→", link)
+    print("  ", snippet.replace("<em>", "").replace("</em>", ""))   # 去掉高亮标签
+
+for f in d["fields"]:                         # 相关课程（可选展示）
+    print("课程：", f["node_name"], "→", course_url(f["field_id"], **DEFAULTS))
+```
+
+`articles[]` 每项关键字段：
+- `type`：`"article"`（词条/主题）或 `"keyword"`（关键词）——**决定用哪种链接**。
+- `id`：词条是 `entry_id`，关键词是 `keyword_id`。
+- `article_name`：标题。
+- `matched_elements[].content`：命中的高亮片段，可直接当**简介**（含 `<em>` 高亮标签，展示前去掉）。
+
+### 想要更完整的简介 / 全文
+
+`/search/universal` 给的是检索片段。要正文，再按类型取详情：
+
+```python
+# 词条（主题文章）全文
+doc = data(requests.post(f"{BASE}/article", headers=H,
+                         json={"entry_id": "<entry_id>", **DEFAULTS}))["document"]
+
+# 关键词全文
+doc = data(requests.post(f"{BASE}/keyword", headers=H,
+                         json={"keyword_id": "<keyword_id>", **DEFAULTS}))["document"]
+
+# doc 常用字段：
+#   article_name    标题
+#   seo_description 一句话简介（最适合做摘要）
+#   definition      定义
+#   key_points      要点
+#   main_content    正文（Markdown）
+#   applications    应用
+```
+
+> ⚠️ `article` / `keyword` 偶尔返回 `code=250002`（内容按需生成、当前语言/风格下还没有）。这时**回退**用搜索结果里的 `matched_elements` 片段，或换一个 `style` / `language` 再试。
+
+---
+
+## 任务 2：看百科里有哪些领域和课程
+
+**按学科浏览**：先拿大类与分级，再列某个分级下的课程。
+
+```python
+# 1) 顶层结构：大类(major) → 分级(level)
+ml = data(requests.post(f"{BASE}/major_levels", headers=H, json={**DEFAULTS}))
+for m in ml["majors"]:
+    levels = "、".join(l["name"] for l in m["levels"])
+    print(m["name"], "｜分级：", levels)
+
+# 2) 列出某些分级下的课程(field)
+level_ids = [lv["node_id"] for m in ml["majors"] for lv in m["levels"]]
+lf = data(requests.post(f"{BASE}/level_fields", headers=H,
+                        json={"node_ids": level_ids[:5], "page_num": 1, "page_size": 20, **DEFAULTS}))
+for it in lf["items"]:
+    f = it["field"]
+    print(f'{it["major"]["name"]} / {it["level"]["name"]} / {f["name"]}'
+          f'（{it.get("topic_count", 0)} 个知识点）→', course_url(f["field_id"], **DEFAULTS))
+```
+
+- `major_levels` 返回 `majors[]`，每个含 `name` 和 `levels[]`（`name` + `node_id`）。
+- `level_fields` 返回分页 `items[]`（`total` 为总数），每项含 `major` / `level` / `field`、`topic_count`、以及若干示例 `topics`；其中 `field` 带 `node_id`、`name`、`seo_title` 和 **`field_id`**。
+
+> 课程**阅读链接**直接用 `field.field_id` 拼（`course_url(...)`，见[拼阅读链接](#拼阅读链接)）；想要章节结构就把 `field_id`（或 `field.node_id`）传给任务 3 的 `get_wiki_index`。
+
+---
+
+## 任务 3：给定课程，拿章节结构和知识点列表
+
+两步：用课程名找到课程 → 用课程取整棵章节树。
+
+```python
+# 1) 用课名定位课程（拿到 field_id）
+s = data(requests.post(f"{BASE}/search/universal", headers=H,
+                       json={"text": "Solid State Physics", **DEFAULTS}))
+field = s["fields"][0]                 # 含 node_id、field_id、node_name
+
+# 2) 取章节结构 + 知识点（传 field_id，或传该 field 的 node_id 也行）
+tree = data(requests.post(f"{BASE}/get_wiki_index", headers=H,
+                          json={"field_id": field["field_id"], **DEFAULTS}))
+
+def walk(nodes, depth=0):
+    for n in nodes:
+        print("  " * depth, f'[{n["node_type"]}]', n["node_name"])
+        if n["node_type"] == "entry":          # 叶子 = 一个知识点（词条）
+            print("  " * (depth + 1), "→", topic_url(n["entry_id"], **DEFAULTS))
+        walk(n.get("children") or [], depth + 1)
+
+walk(tree["wiki_indices"])
+print("总知识点：", tree.get("entry_count"))
+```
+
+- 树是 4 层：`field`（课程）→ `category`（大章）→ `chapter`（小节）→ `entry`（知识点/词条）。
+- 每个节点：`node_id`、`node_type`、`node_name`；**叶子 `entry` 节点额外带 `entry_id`**（拼阅读链接用）、`snapshot`（AI 速览，适合当一句话摘要）、`seo_title`。
+- 顶层还返回 `entry_count` 及 `foundational_entry_count` / `core_entry_count` / `advanced_entry_count`（基础 / 核心 / 进阶知识点数）。
+
+---
+
+## 任务 4：从一个主题出发，拿知识图谱
+
+从某个中心节点（词条或关键词）向外扩展，得到它和相关概念组成的图。
+
+```python
+# 1) 先找到中心节点的 id（词条用 entry_id，关键词用 keyword_id）
+s = data(requests.post(f"{BASE}/search/universal", headers=H,
+                       json={"text": "superconductivity", **DEFAULTS}))
+center_id = s["articles"][0]["id"]
+# 也可以用图谱内检索直接找节点：
+# gs = data(requests.post(f"{BASE}/knowledge_graph/search", headers=H, json={"text": "entropy"}))
+# center_id = gs["items"][0]["id"]
+
+# 2) 取图谱（注意：是 GET + query 参数）
+g = data(requests.get(f"{BASE}/knowledge_graph", headers=H,
+                      params={"id": center_id, **DEFAULTS}))
+
+for n in g["nodes"]:                  # 节点
+    link = build_read_url(n["node_type"], n["node_id"], **DEFAULTS)
+    print(n["display_name"], f'({n["node_type"]}, 深度{n["depth"]})', "→", link)
+
+for e in g["relationships"]:          # 边
+    print(e["src_node_id"], "──", e["relationship"], "──>", e["desc_node_id"],
+          f'(权重 {e["weight"]})')
+```
+
+- 入参：`id`（必填，中心节点的 `entry_id` 或 `keyword_id`）、`language`、`style`、可选 `skip_cross_domain`（true=只看同领域）。
+- `nodes[]`：`node_id`（就是 `entry_id`/`keyword_id`，可直接拼链接）、`node_type`（`entry`/`keyword`）、`display_name`、`description`、`field_name`、`major_name`、`depth`（中心节点为 0）。
+- `relationships[]`：`src_node_id` / `desc_node_id`、`relationship`（关系描述）、`relation_type`、`description`、`weight`、`evidence_count`、`is_bidirectional`、`is_cross_domain`。
+- `domains[]`：图里涉及的学科（`major_node_id` + `major_name`）。
+
+### 看某个节点 / 某条边的细节
+
+```python
+# 单个节点详情
+node = data(requests.get(f"{BASE}/knowledge_graph/node", headers=H,
+            params={"id": center_id, "node_type": "entry", **DEFAULTS}))
+
+# 单条关系详情（含支撑证据 evidences）
+rel = data(requests.get(f"{BASE}/knowledge_graph/relationship", headers=H,
+           params={"src_node_id": "A", "desc_node_id": "B", "relation_id": "R", **DEFAULTS}))
 ```
 
 ---
 
-## 2. 大类与分级 — `major_levels`
+## 动作速查表
 
-```python
-r = requests.post(f"{BASE}/major_levels", headers=H, json={**DEFAULTS})
-for m in r.json().get("majors", []):
-    levels = ", ".join(l["name"] for l in m.get("levels", []))
-    print(f"- {m['name']} [{m['node_id']}]  levels: {levels}")
-```
+| 任务 | 方法 + 路径 | 用途 |
+|------|------------|------|
+| 搜索（首选） | `POST /search/universal` | 一个词拿到词条 + 关键词 + 相关课程 |
+| 词条全文 | `POST /article` | 按 `entry_id`（或 `node_id`）取主题文章正文 |
+| 关键词全文 | `POST /keyword` | 按 `keyword_id` 取关键词内容 |
+| 学科结构 | `POST /major_levels` | 所有大类及其分级 |
+| 课程列表 | `POST /level_fields` | 某些分级下的课程（分页） |
+| 课程结构 | `POST /get_wiki_index` | 课程的章节树 + 知识点（叶子带 `entry_id`） |
+| 知识图谱 | `GET /knowledge_graph` | 从一个主题/关键词扩展出图谱 |
+| 图谱·节点 | `GET /knowledge_graph/node` | 单个节点详情 |
+| 图谱·边 | `GET /knowledge_graph/relationship` | 单条关系详情（含证据） |
+| 图谱·检索 | `POST /knowledge_graph/search` | 在图谱里按词找节点 |
+| （可选）基础信息 | `GET /info` | 词条 / 关键词总量 |
+| （可选）名称搜索 | `POST /search_index_name` | 按名字搜节点（如只要 `field`） |
 
----
-
-## 3. 搜索词条 — `search_index_name`
-
-```python
-r = requests.post(f"{BASE}/search_index_name", headers=H, json={
-    "name": "graphene",
-    "node_types": ["field"],   # 过滤节点类型：major / level / field / topic
-    "style": "Feynman",
-})
-for i, n in enumerate(r.json().get("wiki_indices", []), 1):
-    print(f"[{i}] [{n['node_type']}] {n['node_name']}  id={n['node_id']}")
-```
+> 所有响应都包了一层 `{"code":0,"data":{...}}`，用上面的 `data()` 解包。`GET` 类用 `params=`，`POST` 类用 `json=`。
 
 ---
 
-## 4. 某一分级下的所有节点 — `get_level_wiki_index`
+## 拼阅读链接
+
+凡是展示给人的词条 / 关键词 / 课程，都附上 `https://www.bohrium.com` 上的阅读链接（**不是** API host）。
+
+规则：
+- **语言前缀**：`zh-CN` → 无前缀；`en-US` → 加 `/en`。
+- **风格段**：小写，`Feynman → feynman`、`Hardcore → hardcore`。
+- 动态 id 要 **URL 编码**。
+
+| 类型 | 模板 | id 来源 |
+|------|------|---------|
+| 词条 / 主题 | `{前缀}/sciencepedia/{style}/{entry_id}` | 搜索结果 `type=article` 的 `id`；课程树叶子的 `entry_id`；图谱里 `node_type=entry` 的 `node_id` |
+| 关键词 | `{前缀}/sciencepedia/{style}/keyword/{keyword_id}` | 搜索结果 `type=keyword` 的 `id`；图谱里 `node_type=keyword` 的 `node_id` |
+| 课程 / 领域 | `{前缀}/sciencepedia/field/{style}/{field_id}` | `/search/universal` 的 `fields[].field_id`，或 `/level_fields` 的 `items[].field.field_id` |
 
 ```python
-r = requests.post(f"{BASE}/get_level_wiki_index", headers=H, json={
-    "node_types": ["major", "level"],
-    **DEFAULTS,
-})
-for n in r.json().get("wiki_indices", [])[:50]:
-    print(f"[{n['node_type']}] {n['node_name']}  ({n['node_id']})")
+def _site(language):
+    return "https://www.bohrium.com/en" if language == "en-US" else "https://www.bohrium.com"
+
+def topic_url(entry_id, language="en-US", style="Feynman"):
+    return f"{_site(language)}/sciencepedia/{style.lower()}/{quote(str(entry_id))}"
+
+def keyword_url(keyword_id, language="en-US", style="Feynman"):
+    return f"{_site(language)}/sciencepedia/{style.lower()}/keyword/{quote(str(keyword_id))}"
+
+def course_url(field_id, language="en-US", style="Feynman"):
+    return f"{_site(language)}/sciencepedia/field/{style.lower()}/{quote(str(field_id))}"
+
+def build_read_url(node_type, node_id, language="en-US", style="Feynman"):
+    # node_type: "keyword" -> 关键词页；其余（article/entry）-> 词条页
+    if node_type == "keyword":
+        return keyword_url(node_id, language, style)
+    return topic_url(node_id, language, style)
 ```
 
----
-
-## 5. 获取词条索引 — `get_wiki_index`
-
-```python
-r = requests.post(f"{BASE}/get_wiki_index", headers=H, json={
-    "node_id": "NODE_ID_HERE",
-    # 或 "field_id": "FIELD_ID_HERE"
-    **DEFAULTS,
-})
-print(r.json())
+示例：
+```text
+词条（en, Feynman）：    https://www.bohrium.com/en/sciencepedia/feynman/<entry_id>
+关键词（zh, Feynman）：  https://www.bohrium.com/sciencepedia/feynman/keyword/<keyword_id>
+课程（en, Hardcore）：   https://www.bohrium.com/en/sciencepedia/field/hardcore/<field_id>
 ```
-
----
-
-## 6. 批量列出 level 下的领域 — `level_fields`
-
-```python
-r = requests.post(f"{BASE}/level_fields", headers=H, json={
-    "node_ids": ["LEVEL_NODE_ID1", "LEVEL_NODE_ID2"],
-    "page_num": 1, "page_size": 10,
-    **DEFAULTS,
-})
-for row in r.json().get("items", []):
-    major = row.get("major", {}).get("name")
-    level = row.get("level", {}).get("name")
-    field = row.get("field", {}).get("name")
-    print(f"- {major}/{level}/{field}  topics={row.get('topic_count')}")
-```
-
----
-
-## 7. 获取词条正文 — `article`
-
-```python
-r = requests.post(f"{BASE}/article", headers=H, json={
-    "node_id": "NODE_ID",         # 或 "entry_id": "ENTRY_ID"
-    **DEFAULTS,
-})
-doc = r.json().get("document", {})
-print(f"# {doc.get('article_name')}")
-print(doc.get("main_content", "")[:2000])
-```
-
-**常用字段**：`document.article_name` / `document.main_content` / `document.applications` / `document.seo_title`。
 
 ---
 
@@ -203,55 +291,42 @@ print(doc.get("main_content", "")[:2000])
 AK="$BOHR_ACCESS_KEY"
 BASE="https://open.bohrium.com/openapi/v2/literature-sage/wiki_v2"
 
-# 按关键词搜词条
-curl -s -X POST "$BASE/search_index_name" \
+# 统一搜索
+curl -s -X POST "$BASE/search/universal" \
   -H "Authorization: Bearer $AK" -H "Content-Type: application/json" \
-  -d '{"name":"graphene","node_types":["field"],"style":"Feynman"}' \
-  | jq '.wiki_indices[] | {node_name, node_type, node_id}'
+  -d '{"text":"graphene","language":"en-US","style":"Feynman"}' \
+  | jq '.data.articles[] | {type, id, article_name}'
+
+# 知识图谱（GET + query）
+curl -s -G "$BASE/knowledge_graph" \
+  -H "Authorization: Bearer $AK" \
+  --data-urlencode "id=<entry_id_or_keyword_id>" \
+  --data-urlencode "language=en-US" --data-urlencode "style=Feynman" \
+  | jq '.data | {nodes: (.nodes|length), edges: (.relationships|length)}'
 ```
 
 ---
-
-## 构造页面链接
-
-每当你把词条或领域展示给人看时，都要附上 `https://www.bohrium.com` 上的可点击阅读链接（**不是** API host）。这才是让回答对人有用的关键。
-
-- **页面 Host**：`https://www.bohrium.com`
-- **风格段**：`Feynman → feynman`，`Hardcore → hardcore`
-- **语言前缀**：`zh-CN` → 无前缀；`en-US` → 加前缀 `/en`
-- 动态 id 需 **URL 编码**。
-
-| 链接 | 模板 | id 来源 |
-|------|------|---------|
-| 文章（词条） | `{lang}/sciencepedia/{style}/{entry_id}` | `get_wiki_index` 词条节点的 `entry_id`（或你传给 `article` 的 `entry_id`） |
-| 领域（课程） | `{lang}/sciencepedia/field/{style}/{field_id}` | `search_index_name` 领域结果 / `level_fields` 的 `field_id` |
-
-```text
-文章（en, Feynman）： https://www.bohrium.com/en/sciencepedia/feynman/<entry_id>
-领域（zh, Feynman）： https://www.bohrium.com/sciencepedia/field/feynman/solid_state_physics
-```
-
-> 本 skill 只开放文章/领域阅读，没有关键词（keyword）页面链接。
 
 ## 回答规范
 
-- 优先**教学式**回答：定义 → 直觉 → 要点 → 在知识树中的位置。
-- 凡是提到的词条或领域，都附上阅读链接（`article_url` / `course_url`）。
-- 若所请求的 `language`/`style` 无结果，按序回退：同语言换另一风格 → `zh-CN`+`Feynman` → `en-US`+`Feynman`，并告知用户已切换。
-- API 失败要如实说明；无结果时给出近义词建议和一个备选语言/风格。
-
----
+- **搜索类**：直接给「标题 + 一句话简介 + 阅读链接」的列表，不用向用户解释「词条 / 关键词」的区别。
+- **解释概念**：定义 → 直觉 → 要点，并附该条目的阅读链接。
+- **课程结构**：按 章 → 节 → 知识点 的层级呈现，每个知识点带链接；可按基础 / 核心 / 进阶分组（用 `*_entry_count`）。
+- **知识图谱**：先讲中心节点，再列最相关的几条关系（按 `weight` 排），需要展开时再调 `node` / `relationship` 详情。
+- 凡是提到的条目都附阅读链接。指定的 `language`/`style` 无结果时，按序回退：同语言换另一风格 → `zh-CN`+`Feynman` → `en-US`+`Feynman`，并告知已切换。
+- API 失败要如实说明；无结果时给近义词建议和一个备选语言 / 风格。
 
 ## 常见问题
 
-| 问题 | 原因 | 解决 |
+| 现象 | 原因 | 解决 |
 |------|------|------|
-| `No matches for "..."` | 关键词在索引里不存在 | 换近义词；打开 `node_types` 为 `["field","topic","major","level"]` 扩大搜索 |
-| `article` 返回空 | nodeId/entryId 错或该节点无正文 | 先用 `search_index_name` 拿到正确的 `node_id` |
-| 结果全是英文（或全是中文） | `language` 不对 | 指定 `"language": "en-US"` 或 `"zh-CN"` |
-| 阅读链接拼到了 `open.bohrium.com` 上 | 混淆了 API host 与页面 host | 页面链接用 `https://www.bohrium.com`（见“构造页面链接”） |
+| 搜不到 | 词不在索引里 | 换近义词；或用 `/search_index_name` 放开 `node_types` |
+| `article`/`keyword` 返回 `250002` | 该语言/风格下内容尚未生成 | 回退到搜索片段，或换 `style`/`language` 重试 |
+| 结果全英文（或全中文） | `language` 不对 | 指定 `"language":"en-US"` 或 `"zh-CN"` |
+| 知识图谱为空 | `id` 不是有效的 `entry_id`/`keyword_id`，或该节点无邻居 | 先用 `/search/universal` 或 `/knowledge_graph/search` 拿到正确 id |
+| 阅读链接拼到了 `open.bohrium.com` | 混淆了 API host 与页面 host | 页面链接用 `https://www.bohrium.com`（见[拼阅读链接](#拼阅读链接)） |
 
 ## 搭配使用
 
-- **wiki** 找某个概念的基础解释 → **paper-search** 深入某个具体方向
-- **wiki** 浏览学科目录（`major_levels`）→ 选定 field → **scholar** 找代表学者
+- **wiki** 拿概念的基础解释 → **bohrium-paper-search** 深入某个方向
+- **wiki** 浏览学科目录（`major_levels`）→ 选定课程 → **bohrium-scholar-search** 找代表学者


### PR DESCRIPTION
## Summary

把原 `bohrium-wiki` skill 整体重命名为 **`bohrium-sciencepedia`**，并围绕 4 个用户任务（搜词条/关键词、浏览领域课程、看课程章节、查知识图谱）重写文档、补充端点实测。

### 1. 重命名 bohrium-wiki → bohrium-sciencepedia

- 文件夹：`en/bohrium-wiki/` → `en/bohrium-sciencepedia/`，`zh/bohrium-wiki/` → `zh/bohrium-sciencepedia/`
- SKILL.md：`name` 与认证配置示例 key 同步更新
- `README.md` / `README_EN.md`：表格条目与链接同步
- `.claude-plugin/marketplace.json`：插件 skills 列表项更名并保持字典序
- `en/zh bohrium-tools/SKILL.md`：跨 skill 引用同步
- `tests/VERIFICATION_REPORT.md` / `tests/smoke_test.py`：标识符同步（保留 "原 bohrium-wiki" 历史注解）
- API 网关路径 `/wiki_v2/*` 不变，故 BASE URL 与端点路径保持原状

### 2. 围绕 4 个用户任务重写 SKILL.md（en + zh）

- **任务 1**：搜一个词 → 简介 + 阅读链接（`/search/universal` 一次返回 topic + keyword + 相关 course）
- **任务 2**：看百科里有哪些领域和课程（`/major_levels` + `/level_fields`）
- **任务 3**：给定课程 → 章节结构 + 知识点（`/get_wiki_index`）
- **任务 4**：从一个主题出发 → 知识图谱（`/knowledge_graph`，含 `/node`、`/relationship`、`/search`）
- 统一三类阅读链接（topic / keyword / course）拼装规则与 `data()` 解包模板

### 3. 端点实测补充

`tests/VERIFICATION_REPORT.md` 增加 2026-06-26 真实实测：重写后覆盖的 12 个端点全部 HTTP 200 / `code=0`；把历史 `article 250002` 标记为已澄清（仅是无内容个例，用正确 `entry_id` 可取全文）。

## Test plan

- [x] 2026-06-26 用真实 AK 跑冒烟脚本：`/search/universal`、`/article`、`/keyword`、`/major_levels`、`/level_fields`、`/get_wiki_index`、`/knowledge_graph`(+ node / relationship / search)、`/info`、`/search_index_name` 共 12 个端点全通
- [x] 课程链接用 `field.field_id` 直接拼装可正常打开
- [x] 知识图谱端点确认为 `GET + 单个 id`（修正 Apifox 上的 POST+ids 标注）
- [x] 仓库内已无残留的 `bohrium-wiki` 标识（API 路径 `/wiki_v2/*` 除外，按网关现状保留）