### PR TITLE
feat: add bohrium skills cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,17 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version, for example 0.1.0"
+        required: true
+        type: string
+      publish_npm:
+        description: "Publish npm package when NPM_TOKEN is configured"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -27,11 +38,25 @@ jobs:
       - name: Test
         run: go test ./...
 
+      - name: Resolve version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            version="${{ inputs.version }}"
+          else
+            version="${GITHUB_REF_NAME#v}"
+          fi
+          version="${version#v}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
       - name: Build release assets
         shell: bash
         run: |
           set -euo pipefail
-          version="${GITHUB_REF_NAME#v}"
+          version="${{ steps.version.outputs.version }}"
           mkdir -p dist
           for goos in darwin linux windows; do
             for goarch in amd64 arm64; do
@@ -49,10 +74,24 @@ jobs:
 
       - uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          target_commitish: ${{ github.sha }}
           files: dist/*
           generate_release_notes: true
 
       - name: Publish npm package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --provenance
+          PUBLISH_NPM: ${{ github.event_name == 'push' || inputs.publish_npm }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$PUBLISH_NPM" != "true" ]; then
+            echo "npm publish skipped by workflow input"
+            exit 0
+          fi
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "NPM_TOKEN is not configured; skipping npm publish"
+            exit 0
+          fi
+          npm publish --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.x"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Test
+        run: go test ./...
+
+      - name: Build release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          mkdir -p dist
+          for goos in darwin linux windows; do
+            for goarch in amd64 arm64; do
+              ext=""
+              if [ "$goos" = "windows" ]; then
+                ext=".exe"
+              fi
+              GOOS="$goos" GOARCH="$goarch" go build \
+                -ldflags "-s -w -X github.com/dptech-corp/bohrium-skills/internal/build.Version=$version" \
+                -o "dist/bohrium-skills-cli_${goos}_${goarch}${ext}" \
+                ./cmd/bohrium-skills-cli
+            done
+          done
+          (cd dist && shasum -a 256 * > checksums.txt)
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true
+
+      - name: Publish npm package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,4 +94,6 @@ jobs:
             echo "NPM_TOKEN is not configured; skipping npm publish"
             exit 0
           fi
+          npm pkg set repository.type=git
+          npm pkg set "repository.url=git+https://github.com/${GITHUB_REPOSITORY}.git"
           npm publish --access public --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
         required: true
         type: string
       publish_npm:
-        description: "Publish npm package when NPM_TOKEN is configured"
+        description: "Publish npm package through npm Trusted Publishing"
         required: false
         default: false
         type: boolean
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Test
@@ -81,17 +81,12 @@ jobs:
 
       - name: Publish npm package
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           PUBLISH_NPM: ${{ github.event_name == 'push' || inputs.publish_npm }}
         shell: bash
         run: |
           set -euo pipefail
           if [ "$PUBLISH_NPM" != "true" ]; then
             echo "npm publish skipped by workflow input"
-            exit 0
-          fi
-          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
-            echo "NPM_TOKEN is not configured; skipping npm publish"
             exit 0
           fi
           npm pkg set repository.type=git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,4 +94,4 @@ jobs:
             echo "NPM_TOKEN is not configured; skipping npm publish"
             exit 0
           fi
-          npm publish --provenance
+          npm publish --access public --provenance

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,14 @@ __pycache__/
 .idea/
 .vscode/
 *.swp
+
+# Go / release artifacts
+.gocache/
+dist/
+bin/bohrium-skills-cli.exe
+
+# Local npm cache used for dry-run tests
+.npm-cache/
+
+# Local reference checkout used for implementation notes
+references/

--- a/README.md
+++ b/README.md
@@ -90,15 +90,15 @@ bohrium-skills-cli install --lang zh --json
 BOHRIUM_SKILLS_CLI_NO_POSTINSTALL_SYNC=1 npm install -g bohrium-skills-cli
 ```
 
-如需先从 fork 的 GitHub Release 测试二进制下载，可覆盖 release 仓库地址：
+如需测试本地打包产物的 postinstall 下载逻辑，可临时覆盖 release 仓库地址：
 
 ```bash
-BOHRIUM_SKILLS_CLI_RELEASE_REPO=https://github.com/Grenzlinie/bohrium-skills npm install -g ./bohrium-skills-cli-0.1.0.tgz
+BOHRIUM_SKILLS_CLI_RELEASE_REPO=https://github.com/OWNER/REPO npm install -g ./bohrium-skills-cli-0.1.0.tgz
 ```
 
 ### 方式二：GitHub Release 二进制安装
 
-如果没有 npm 账号，或只想使用 GitHub Release 发布的单文件二进制，可以手动下载对应平台的 release asset：
+如果只想使用 GitHub Release 发布的单文件二进制，可以手动下载对应平台的 release asset：
 
 ```bash
 # macOS Apple Silicon

--- a/README.md
+++ b/README.md
@@ -56,6 +56,112 @@ export BOHR_ACCESS_KEY="your_access_key_here"
 
 装完会得到 17 个 Bohrium skill（英文版）。
 
+## CLI 安装与更新
+
+推荐用 `bohrium-skills-cli` 管理本仓库的整套 skills。CLI 发布包内嵌 `zh/` 和 `en/` 两套 skill，默认安装中文版，并同步到：
+
+- `~/.agents/skills`
+- `~/.claude/skills`
+- `~/.codex/skills`
+
+使用 CLI 的好处：
+
+- **不用反复下载和手动替换目录**：安装或更新 CLI 后，内嵌的最新版 skills 会自动同步到常用 agent 目录。
+- **版本一致**：CLI 版本和内嵌 skill set 绑定，排查问题时可以通过 `status` 看到本地同步状态。
+- **安全可恢复**：替换同名官方 skill 前会自动备份，误覆盖时可以从备份目录找回。
+- **不影响自定义 skills**：同步只管理官方 `bohrium-*` skills，不会触碰其他自定义目录。
+- **适合多工具共用**：一次同步即可覆盖 OpenAI Codex、Claude Code、agents 等常见 skill 目录。
+
+### 方式一：npm 安装
+
+```bash
+npm install -g bohrium-skills-cli
+```
+
+npm 安装完成后会自动运行：
+
+```bash
+bohrium-skills-cli install --lang zh --json
+```
+
+如需跳过安装后的自动同步（例如 CI 或只想下载二进制）：
+
+```bash
+BOHRIUM_SKILLS_CLI_NO_POSTINSTALL_SYNC=1 npm install -g bohrium-skills-cli
+```
+
+### 方式二：GitHub Release 二进制安装
+
+如果没有 npm 账号，或只想使用 GitHub Release 发布的单文件二进制，可以手动下载对应平台的 release asset：
+
+```bash
+# macOS Apple Silicon
+curl -L -o bohrium-skills-cli \
+  https://github.com/dptech-corp/bohrium-skills/releases/download/v0.1.0/bohrium-skills-cli_darwin_arm64
+
+chmod +x bohrium-skills-cli
+mkdir -p ~/.local/bin
+mv bohrium-skills-cli ~/.local/bin/bohrium-skills-cli
+export PATH="$HOME/.local/bin:$PATH"
+
+bohrium-skills-cli version
+bohrium-skills-cli list
+bohrium-skills-cli install
+bohrium-skills-cli status
+```
+
+不同平台的二进制文件名：
+
+```text
+macOS Apple Silicon: bohrium-skills-cli_darwin_arm64
+macOS Intel:         bohrium-skills-cli_darwin_amd64
+Linux x86_64:        bohrium-skills-cli_linux_amd64
+Linux ARM64:         bohrium-skills-cli_linux_arm64
+Windows x86_64:      bohrium-skills-cli_windows_amd64.exe
+Windows ARM64:       bohrium-skills-cli_windows_arm64.exe
+```
+
+手动二进制安装不会自动同步 skills，需要显式运行：
+
+```bash
+bohrium-skills-cli install
+```
+
+如果是 GitHub Release 二进制手动安装，`bohrium-skills-cli update` 不会自动替换当前二进制；它会提示新版本 Release 地址，并同步当前二进制内嵌的 skills。自动更新二进制主要用于 npm 安装路径。
+
+### 更新
+
+```bash
+bohrium-skills-cli update
+```
+
+如果 CLI 是通过 npm 安装的，`update` 会先更新 `bohrium-skills-cli` 二进制，再用新版本内嵌的 skills 同步本地三处目录。如果不是 npm 安装，则会提示 GitHub Release 下载地址，并同步当前二进制内嵌的 skills。
+
+常用命令：
+
+```bash
+bohrium-skills-cli status
+# 查看当前 CLI 版本、本地 skills 同步版本、语言、状态文件和目标目录安装情况。
+
+bohrium-skills-cli list
+# 列出当前 CLI 内嵌的官方 skills；默认显示 zh 版本的 17 个 bohrium-* skills。
+
+bohrium-skills-cli install --force
+# 强制重新安装默认 zh 版本的全部官方 skills；适合恢复被手动删除或改坏的 skill。
+
+bohrium-skills-cli install --lang en
+# 安装英文版 skills；会同步 en/ 下的同名 bohrium-* skills 到三处目标目录。
+
+bohrium-skills-cli update --check --json
+# 只检查 npm 上是否有新版 CLI，并以 JSON 输出结果；不会更新二进制，也不会写入 skills 目录。
+```
+
+同步只管理官方 `bohrium-*` skills，不会触碰其他自定义 skills。替换同名 skill 前会备份到：
+
+```text
+~/.config/bohrium-skills-cli/backups/<timestamp>/
+```
+
 ---
 
 ## Skill 列表

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ bohrium-skills-cli install --lang zh --json
 BOHRIUM_SKILLS_CLI_NO_POSTINSTALL_SYNC=1 npm install -g bohrium-skills-cli
 ```
 
+如需先从 fork 的 GitHub Release 测试二进制下载，可覆盖 release 仓库地址：
+
+```bash
+BOHRIUM_SKILLS_CLI_RELEASE_REPO=https://github.com/Grenzlinie/bohrium-skills npm install -g ./bohrium-skills-cli-0.1.0.tgz
+```
+
 ### 方式二：GitHub Release 二进制安装
 
 如果没有 npm 账号，或只想使用 GitHub Release 发布的单文件二进制，可以手动下载对应平台的 release asset：

--- a/README_EN.md
+++ b/README_EN.md
@@ -58,6 +58,45 @@ This installs 17 Bohrium skills (English versions).
 
 ---
 
+## CLI Install And Update
+
+Use `bohrium-skills-cli` to install and update the bundled skill set:
+
+```bash
+npm install -g bohrium-skills-cli
+```
+
+The npm `postinstall` downloads the platform binary and runs:
+
+```bash
+bohrium-skills-cli install --lang zh --json
+```
+
+By default the CLI syncs the bundled skills to:
+
+- `~/.agents/skills`
+- `~/.claude/skills`
+- `~/.codex/skills`
+
+Useful commands:
+
+```bash
+bohrium-skills-cli update
+bohrium-skills-cli status
+bohrium-skills-cli install --force
+bohrium-skills-cli install --lang en
+```
+
+To skip postinstall skill sync while still installing the binary:
+
+```bash
+BOHRIUM_SKILLS_CLI_NO_POSTINSTALL_SYNC=1 npm install -g bohrium-skills-cli
+```
+
+The sync only manages official `bohrium-*` skills. Existing same-name skills are backed up under `~/.config/bohrium-skills-cli/backups/<timestamp>/` before replacement.
+
+---
+
 ## Skill List
 
 ### Platform API Skills

--- a/README_EN.md
+++ b/README_EN.md
@@ -93,10 +93,10 @@ To skip postinstall skill sync while still installing the binary:
 BOHRIUM_SKILLS_CLI_NO_POSTINSTALL_SYNC=1 npm install -g bohrium-skills-cli
 ```
 
-To test binary downloads from a fork release before the official release is available:
+To test postinstall binary downloads from a locally packed tarball, temporarily override the release repository:
 
 ```bash
-BOHRIUM_SKILLS_CLI_RELEASE_REPO=https://github.com/Grenzlinie/bohrium-skills npm install -g ./bohrium-skills-cli-0.1.0.tgz
+BOHRIUM_SKILLS_CLI_RELEASE_REPO=https://github.com/OWNER/REPO npm install -g ./bohrium-skills-cli-0.1.0.tgz
 ```
 
 The sync only manages official `bohrium-*` skills. Existing same-name skills are backed up under `~/.config/bohrium-skills-cli/backups/<timestamp>/` before replacement.

--- a/README_EN.md
+++ b/README_EN.md
@@ -93,6 +93,12 @@ To skip postinstall skill sync while still installing the binary:
 BOHRIUM_SKILLS_CLI_NO_POSTINSTALL_SYNC=1 npm install -g bohrium-skills-cli
 ```
 
+To test binary downloads from a fork release before the official release is available:
+
+```bash
+BOHRIUM_SKILLS_CLI_RELEASE_REPO=https://github.com/Grenzlinie/bohrium-skills npm install -g ./bohrium-skills-cli-0.1.0.tgz
+```
+
 The sync only manages official `bohrium-*` skills. Existing same-name skills are backed up under `~/.config/bohrium-skills-cli/backups/<timestamp>/` before replacement.
 
 ---

--- a/bin/bohrium-skills-cli
+++ b/bin/bohrium-skills-cli
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+echo "bohrium-skills-cli binary has not been installed yet; rerun npm install -g bohrium-skills-cli" >&2
+exit 1

--- a/bundle.go
+++ b/bundle.go
@@ -1,0 +1,129 @@
+package bohriumskills
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+)
+
+// EmbeddedFS contains the bundled Bohrium skills.
+//
+//go:embed zh/** en/**
+var EmbeddedFS embed.FS
+
+type Skill struct {
+	Lang  string
+	Name  string
+	Path  string
+	Files []string
+}
+
+func (s Skill) HasFile(name string) bool {
+	for _, file := range s.Files {
+		if file == name {
+			return true
+		}
+	}
+	return false
+}
+
+func OfficialSkills(lang string) ([]Skill, error) {
+	if lang != "zh" && lang != "en" {
+		return nil, fmt.Errorf("unsupported language %q", lang)
+	}
+	entries, err := fs.ReadDir(EmbeddedFS, lang)
+	if err != nil {
+		return nil, err
+	}
+
+	var skills []Skill
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "bohrium-") {
+			continue
+		}
+		skillPath := path.Join(lang, entry.Name())
+		data, err := fs.ReadFile(EmbeddedFS, path.Join(skillPath, "SKILL.md"))
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", skillPath, err)
+		}
+		name, err := frontmatterName(string(data))
+		if err != nil {
+			return nil, fmt.Errorf("%s/SKILL.md: %w", skillPath, err)
+		}
+		var files []string
+		if err := fs.WalkDir(EmbeddedFS, skillPath, func(filePath string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if d.IsDir() {
+				return nil
+			}
+			rel := strings.TrimPrefix(filePath, skillPath+"/")
+			files = append(files, rel)
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+		sort.Strings(files)
+		skills = append(skills, Skill{Lang: lang, Name: name, Path: skillPath, Files: files})
+	}
+	sort.Slice(skills, func(i, j int) bool { return skills[i].Name < skills[j].Name })
+	return skills, nil
+}
+
+func OfficialSkillNames(lang string) ([]string, error) {
+	skills, err := OfficialSkills(lang)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(skills))
+	for _, skill := range skills {
+		names = append(names, skill.Name)
+	}
+	return names, nil
+}
+
+func ValidateEmbeddedSkills() error {
+	for _, lang := range []string{"zh", "en"} {
+		skills, err := OfficialSkills(lang)
+		if err != nil {
+			return err
+		}
+		for _, skill := range skills {
+			if path.Base(skill.Path) != skill.Name {
+				return fmt.Errorf("%s: frontmatter name %q does not match directory", skill.Path, skill.Name)
+			}
+			if !skill.HasFile("SKILL.md") {
+				return fmt.Errorf("%s: missing SKILL.md", skill.Path)
+			}
+		}
+	}
+	return nil
+}
+
+func frontmatterName(text string) (string, error) {
+	lines := strings.Split(text, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return "", fmt.Errorf("missing frontmatter")
+	}
+	for _, line := range lines[1:] {
+		line = strings.TrimSpace(line)
+		if line == "---" {
+			break
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok || strings.TrimSpace(key) != "name" {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		value = strings.Trim(value, `"'`)
+		if value == "" {
+			return "", fmt.Errorf("empty name")
+		}
+		return value, nil
+	}
+	return "", fmt.Errorf("frontmatter name not found")
+}

--- a/bundle_test.go
+++ b/bundle_test.go
@@ -1,0 +1,43 @@
+package bohriumskills
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestOfficialSkillsListsBothLanguages(t *testing.T) {
+	for _, lang := range []string{"zh", "en"} {
+		t.Run(lang, func(t *testing.T) {
+			skills, err := OfficialSkills(lang)
+			if err != nil {
+				t.Fatalf("OfficialSkills(%q) error = %v", lang, err)
+			}
+			if got, want := len(skills), 17; got != want {
+				t.Fatalf("OfficialSkills(%q) length = %d, want %d", lang, got, want)
+			}
+
+			seen := map[string]bool{}
+			for _, skill := range skills {
+				if skill.Lang != lang {
+					t.Fatalf("skill %s language = %q, want %q", skill.Name, skill.Lang, lang)
+				}
+				if filepath.Base(skill.Path) != skill.Name {
+					t.Fatalf("skill path %q base does not match name %q", skill.Path, skill.Name)
+				}
+				if !skill.HasFile("SKILL.md") {
+					t.Fatalf("skill %s missing SKILL.md", skill.Name)
+				}
+				if seen[skill.Name] {
+					t.Fatalf("duplicate skill %q", skill.Name)
+				}
+				seen[skill.Name] = true
+			}
+		})
+	}
+}
+
+func TestValidateEmbeddedSkillsRejectsNameMismatches(t *testing.T) {
+	if err := ValidateEmbeddedSkills(); err != nil {
+		t.Fatalf("ValidateEmbeddedSkills() error = %v", err)
+	}
+}

--- a/cmd/bohrium-skills-cli/main.go
+++ b/cmd/bohrium-skills-cli/main.go
@@ -1,0 +1,513 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	bohriumskills "github.com/dptech-corp/bohrium-skills"
+	"github.com/dptech-corp/bohrium-skills/internal/build"
+	"github.com/dptech-corp/bohrium-skills/internal/skillsnotice"
+	"github.com/dptech-corp/bohrium-skills/internal/syncer"
+	"github.com/dptech-corp/bohrium-skills/internal/updatecheck"
+	"github.com/dptech-corp/bohrium-skills/internal/updater"
+)
+
+const (
+	childSyncEnv        = "BOHRIUM_SKILLS_CLI_CHILD_SYNC"
+	refreshCacheCommand = "__refresh-update-cache"
+)
+
+type noticeState struct {
+	Update *updatecheck.UpdateInfo
+	Skills *skillsnotice.StaleNotice
+}
+
+var activeNoticeState struct {
+	notices *noticeState
+	json    bool
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		printUsage(stderr)
+		return 2
+	}
+	notices := setupNotices(args)
+	activateNotices(notices, hasJSONFlag(args))
+	defer activateNotices(nil, false)
+
+	var code int
+	switch args[0] {
+	case refreshCacheCommand:
+		code = runRefreshUpdateCache(args[1:], stderr)
+	case "install":
+		code = runInstall(args[1:], stdout, stderr)
+	case "update":
+		code = runUpdate(args[1:], stdout, stderr)
+	case "status":
+		code = runStatus(args[1:], stdout, stderr)
+	case "list":
+		code = runList(args[1:], stdout, stderr)
+	case "version":
+		code = runVersion(args[1:], stdout, stderr)
+	case "help", "-h", "--help":
+		printUsage(stdout)
+		code = 0
+	default:
+		fmt.Fprintf(stderr, "unknown command %q\n", args[0])
+		printUsage(stderr)
+		code = 2
+	}
+	if code == 0 && !hasJSONFlag(args) {
+		writeTextNotices(stderr, notices)
+	}
+	return code
+}
+
+func runInstall(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("install", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	lang := fs.String("lang", "zh", "skill language: zh or en")
+	force := fs.Bool("force", false, "restore all official skills")
+	jsonOut := fs.Bool("json", false, "print JSON output")
+	home := fs.String("home", "", "override home directory")
+	configDir := fs.String("config-dir", "", "override config directory")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	result, err := syncer.Sync(syncer.SyncOptions{
+		Version:   build.Version,
+		Lang:      *lang,
+		HomeDir:   *home,
+		ConfigDir: *configDir,
+		Force:     *force,
+		SourceFS:  bohriumskills.EmbeddedFS,
+	})
+	if err != nil {
+		return reportError(stdout, stderr, *jsonOut, err)
+	}
+	if *jsonOut {
+		printJSON(stdout, result)
+		return 0
+	}
+	fmt.Fprintf(stdout, "Skills synced: %d official, %d updated, %d added, %d skipped because deleted locally\n",
+		len(result.Official), len(result.Updated), len(result.Added), len(result.SkippedDeleted))
+	fmt.Fprintf(stdout, "Targets: %s\n", strings.Join(result.TargetDirs, ", "))
+	if result.BackupCount > 0 {
+		fmt.Fprintf(stdout, "Backups written: %d\n", result.BackupCount)
+	}
+	return 0
+}
+
+func runUpdate(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("update", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	lang := fs.String("lang", "zh", "skill language: zh or en")
+	force := fs.Bool("force", false, "force reinstall/update")
+	check := fs.Bool("check", false, "check only")
+	jsonOut := fs.Bool("json", false, "print JSON output")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	runner := updater.RealRunner{
+		SyncFunc: func(version string, force bool) error {
+			return syncForVersion(version, *lang, force)
+		},
+	}
+	result, err := updater.Update(updater.UpdateOptions{
+		CurrentVersion: build.Version,
+		Force:          *force,
+		Check:          *check,
+		Runner:         runner,
+	})
+	if err != nil {
+		return reportError(stdout, stderr, *jsonOut, err)
+	}
+	if *jsonOut {
+		printJSON(stdout, result)
+		return 0
+	}
+	fmt.Fprintln(stdout, result.Message)
+	if result.Action == "manual_required" {
+		fmt.Fprintf(stdout, "Download: %s\n", result.URL)
+	}
+	return 0
+}
+
+func runStatus(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("status", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	jsonOut := fs.Bool("json", false, "print JSON output")
+	home := fs.String("home", "", "override home directory")
+	configDirFlag := fs.String("config-dir", "", "override config directory")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	homeDir, err := resolveHome(*home)
+	if err != nil {
+		return reportError(stdout, stderr, *jsonOut, err)
+	}
+	configDir := *configDirFlag
+	if configDir == "" {
+		configDir = filepath.Join(homeDir, ".config", "bohrium-skills-cli")
+	}
+	state, readable, readErr := syncer.ReadState(configDir)
+	targets := syncer.DefaultTargets(homeDir)
+	if state != nil && len(state.TargetDirs) > 0 {
+		targets = state.TargetDirs
+	}
+	status := map[string]interface{}{
+		"version":        build.Version,
+		"state_readable": readable,
+		"state_path":     syncer.StatePath(configDir),
+		"targets":        inspectTargets(targets),
+	}
+	if state != nil {
+		status["synced_version"] = state.Version
+		status["lang"] = state.Lang
+		status["official"] = len(state.OfficialSkills)
+		status["updated_at"] = state.UpdatedAt
+	}
+	if readErr != nil {
+		status["state_error"] = readErr.Error()
+	}
+	if *jsonOut {
+		printJSON(stdout, status)
+		return 0
+	}
+	fmt.Fprintf(stdout, "bohrium-skills-cli %s\n", build.Version)
+	if state != nil {
+		fmt.Fprintf(stdout, "skills: version=%s lang=%s official=%d\n", state.Version, state.Lang, len(state.OfficialSkills))
+	} else {
+		fmt.Fprintln(stdout, "skills: not synced")
+	}
+	for _, target := range inspectTargets(targets) {
+		fmt.Fprintf(stdout, "%s exists=%v skills=%d\n", target.Dir, target.Exists, target.SkillCount)
+	}
+	return 0
+}
+
+func runList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	lang := fs.String("lang", "zh", "skill language: zh or en")
+	jsonOut := fs.Bool("json", false, "print JSON output")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	skills, err := bohriumskills.OfficialSkills(*lang)
+	if err != nil {
+		return reportError(stdout, stderr, *jsonOut, err)
+	}
+	if *jsonOut {
+		printJSON(stdout, map[string]interface{}{"lang": *lang, "skills": skills})
+		return 0
+	}
+	for _, skill := range skills {
+		fmt.Fprintln(stdout, skill.Name)
+	}
+	return 0
+}
+
+func runVersion(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("version", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	jsonOut := fs.Bool("json", false, "print JSON output")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *jsonOut {
+		printJSON(stdout, map[string]string{"version": build.Version})
+		return 0
+	}
+	fmt.Fprintln(stdout, build.Version)
+	return 0
+}
+
+func syncForVersion(version, lang string, force bool) error {
+	if normalizeVersion(version) != normalizeVersion(build.Version) && os.Getenv(childSyncEnv) == "" {
+		args := []string{"install", "--lang", lang, "--json"}
+		if force {
+			args = append(args, "--force")
+		}
+		cmd := exec.Command("bohrium-skills-cli", args...)
+		cmd.Env = append(os.Environ(), childSyncEnv+"=1")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("new binary skill sync failed: %w\n%s", err, strings.TrimSpace(string(out)))
+		}
+		return nil
+	}
+	_, err := syncer.Sync(syncer.SyncOptions{
+		Version:  version,
+		Lang:     lang,
+		Force:    force,
+		SourceFS: bohriumskills.EmbeddedFS,
+	})
+	return err
+}
+
+type targetStatus struct {
+	Dir        string `json:"dir"`
+	Exists     bool   `json:"exists"`
+	SkillCount int    `json:"skill_count"`
+}
+
+func inspectTargets(targets []string) []targetStatus {
+	statuses := make([]targetStatus, 0, len(targets))
+	for _, target := range targets {
+		status := targetStatus{Dir: target}
+		entries, err := os.ReadDir(target)
+		if err == nil {
+			status.Exists = true
+			for _, entry := range entries {
+				if entry.IsDir() && strings.HasPrefix(entry.Name(), "bohrium-") {
+					status.SkillCount++
+				}
+			}
+		}
+		statuses = append(statuses, status)
+	}
+	return statuses
+}
+
+func resolveHome(home string) (string, error) {
+	if home != "" {
+		return home, nil
+	}
+	return os.UserHomeDir()
+}
+
+func normalizeVersion(version string) string {
+	version = strings.TrimSpace(version)
+	version = strings.TrimPrefix(version, "v")
+	return strings.TrimPrefix(version, "V")
+}
+
+func setupNotices(args []string) *noticeState {
+	updatecheck.SetPending(nil)
+	skillsnotice.SetPending(nil)
+	if skipNotices(args) {
+		return nil
+	}
+
+	if update := updatecheck.CheckCached(build.Version); update != nil {
+		updatecheck.SetPending(update)
+	}
+	startUpdateCacheRefresh(build.Version)
+
+	configDir := noticeConfigDir(args)
+	if skills := skillsnotice.Check(build.Version, configDir); skills != nil {
+		skillsnotice.SetPending(skills)
+	}
+	return currentNotices()
+}
+
+func currentNotices() *noticeState {
+	notices := &noticeState{
+		Update: updatecheck.GetPending(),
+		Skills: skillsnotice.GetPending(),
+	}
+	if notices.Update == nil && notices.Skills == nil {
+		return nil
+	}
+	return notices
+}
+
+func activateNotices(notices *noticeState, jsonOut bool) {
+	activeNoticeState.notices = notices
+	activeNoticeState.json = jsonOut
+}
+
+func skipNotices(args []string) bool {
+	if len(args) == 0 {
+		return true
+	}
+	switch args[0] {
+	case refreshCacheCommand, "help", "-h", "--help", "version", "completion", "completions":
+		return true
+	}
+	for _, arg := range args {
+		switch arg {
+		case "-h", "--help", "help":
+			return true
+		}
+		if strings.Contains(arg, "completion") {
+			return true
+		}
+	}
+	return false
+}
+
+func hasJSONFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--json" || strings.HasPrefix(arg, "--json=") {
+			return true
+		}
+	}
+	return false
+}
+
+func noticeConfigDir(args []string) string {
+	var home string
+	var configDir string
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--home" && i+1 < len(args):
+			home = args[i+1]
+			i++
+		case strings.HasPrefix(arg, "--home="):
+			home = strings.TrimPrefix(arg, "--home=")
+		case arg == "--config-dir" && i+1 < len(args):
+			configDir = args[i+1]
+			i++
+		case strings.HasPrefix(arg, "--config-dir="):
+			configDir = strings.TrimPrefix(arg, "--config-dir=")
+		}
+	}
+	if configDir != "" {
+		return configDir
+	}
+	if home == "" {
+		resolved, err := os.UserHomeDir()
+		if err == nil {
+			home = resolved
+		}
+	}
+	if home == "" {
+		return filepath.Join(".", ".config", "bohrium-skills-cli")
+	}
+	return filepath.Join(home, ".config", "bohrium-skills-cli")
+}
+
+func writeTextNotices(stderr io.Writer, notices *noticeState) {
+	if notices == nil {
+		return
+	}
+	if notices.Update != nil {
+		fmt.Fprintln(stderr, notices.Update.Message())
+	}
+	if notices.Skills != nil {
+		fmt.Fprintln(stderr, notices.Skills.Message())
+	}
+}
+
+func startUpdateCacheRefresh(version string) {
+	if !updatecheck.NeedsRefresh(version) {
+		return
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	cmd := exec.Command(exe, refreshCacheCommand, "--version", version)
+	cmd.Env = os.Environ()
+	if err := cmd.Start(); err != nil {
+		return
+	}
+	_ = cmd.Process.Release()
+}
+
+func runRefreshUpdateCache(args []string, stderr io.Writer) int {
+	fs := flag.NewFlagSet(refreshCacheCommand, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	version := fs.String("version", build.Version, "current version")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	updatecheck.RefreshCache(*version)
+	return 0
+}
+
+func noticeObject(notices *noticeState) map[string]interface{} {
+	if notices == nil {
+		return nil
+	}
+	out := make(map[string]interface{})
+	if notices.Update != nil {
+		out["update"] = map[string]string{
+			"current": notices.Update.Current,
+			"latest":  notices.Update.Latest,
+			"message": notices.Update.Message(),
+			"command": "bohrium-skills-cli update",
+		}
+	}
+	if notices.Skills != nil {
+		out["skills"] = map[string]string{
+			"current": notices.Skills.Current,
+			"target":  notices.Skills.Target,
+			"message": notices.Skills.Message(),
+			"command": "bohrium-skills-cli update",
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func reportError(stdout, stderr io.Writer, jsonOut bool, err error) int {
+	if jsonOut {
+		printJSONRaw(stdout, map[string]interface{}{
+			"ok": false,
+			"error": map[string]string{
+				"message": err.Error(),
+			},
+		})
+		return 1
+	}
+	fmt.Fprintln(stderr, "error:", err)
+	return 1
+}
+
+func printJSON(w io.Writer, value interface{}) {
+	if activeNoticeState.json {
+		value = withNotice(value, noticeObject(activeNoticeState.notices))
+	}
+	printJSONRaw(w, value)
+}
+
+func printJSONRaw(w io.Writer, value interface{}) {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	_ = encoder.Encode(value)
+}
+
+func withNotice(value interface{}, notice map[string]interface{}) interface{} {
+	if len(notice) == 0 {
+		return value
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return value
+	}
+	var object map[string]interface{}
+	if err := json.Unmarshal(data, &object); err != nil || object == nil {
+		return value
+	}
+	object["_notice"] = notice
+	return object
+}
+
+func printUsage(w io.Writer) {
+	fmt.Fprintln(w, `bohrium-skills-cli manages bundled Bohrium AI skills.
+
+Usage:
+  bohrium-skills-cli install [--lang zh|en] [--force] [--json]
+  bohrium-skills-cli update [--check] [--force] [--json]
+  bohrium-skills-cli status [--json]
+  bohrium-skills-cli list [--lang zh|en] [--json]
+  bohrium-skills-cli version [--json]`)
+}

--- a/cmd/bohrium-skills-cli/main_test.go
+++ b/cmd/bohrium-skills-cli/main_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dptech-corp/bohrium-skills/internal/build"
+	"github.com/dptech-corp/bohrium-skills/internal/syncer"
+)
+
+func TestInstallWritesBundledSkillsToThreeTargets(t *testing.T) {
+	home := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"install", "--home", home, "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run install exit = %d, stdout = %s, stderr = %s", code, stdout.String(), stderr.String())
+	}
+
+	var out struct {
+		Lang        string   `json:"lang"`
+		Official    []string `json:"official"`
+		Updated     []string `json:"updated"`
+		TargetDirs  []string `json:"target_dirs"`
+		BackupCount int      `json:"backup_count"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("install output is not JSON: %v\n%s", err, stdout.String())
+	}
+	if out.Lang != "zh" {
+		t.Fatalf("lang = %q, want zh", out.Lang)
+	}
+	if got, want := len(out.Official), 17; got != want {
+		t.Fatalf("official count = %d, want %d", got, want)
+	}
+	if got, want := len(out.TargetDirs), 3; got != want {
+		t.Fatalf("target dir count = %d, want %d", got, want)
+	}
+	for _, dir := range out.TargetDirs {
+		if _, err := os.Stat(filepath.Join(dir, "bohrium-job", "SKILL.md")); err != nil {
+			t.Fatalf("bohrium-job not installed in %s: %v", dir, err)
+		}
+	}
+}
+
+func TestTextCommandEmitsNoticeOnStderrOnly(t *testing.T) {
+	clearNoticeEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	withVersion(t, "0.1.0")
+	writeUpdateState(t, home, "0.2.0")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"list"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run list exit = %d, stdout = %s, stderr = %s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "bohrium-job") {
+		t.Fatalf("stdout missing list output: %s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "bohrium-skills-cli 0.2.0 available, current 0.1.0, run: bohrium-skills-cli update") {
+		t.Fatalf("stderr missing update notice: %s", stderr.String())
+	}
+}
+
+func TestJSONCommandIncludesNoticeObject(t *testing.T) {
+	clearNoticeEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	withVersion(t, "0.2.0")
+	writeUpdateState(t, home, "0.3.0")
+	configDir := filepath.Join(home, ".config", "bohrium-skills-cli")
+	if err := syncer.WriteState(configDir, syncer.State{Version: "0.1.0"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"status", "--home", home, "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run status exit = %d, stdout = %s, stderr = %s", code, stdout.String(), stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("json command wrote stderr notice: %s", stderr.String())
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	notice, ok := out["_notice"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("_notice missing from JSON: %s", stdout.String())
+	}
+	if _, ok := notice["update"].(map[string]interface{}); !ok {
+		t.Fatalf("_notice.update missing: %#v", notice)
+	}
+	if _, ok := notice["skills"].(map[string]interface{}); !ok {
+		t.Fatalf("_notice.skills missing: %#v", notice)
+	}
+}
+
+func TestVersionJSONDoesNotIncludeNotice(t *testing.T) {
+	clearNoticeEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	withVersion(t, "0.1.0")
+	writeUpdateState(t, home, "0.2.0")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"version", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run version exit = %d, stdout = %s, stderr = %s", code, stdout.String(), stderr.String())
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if _, ok := out["_notice"]; ok {
+		t.Fatalf("version JSON included _notice: %s", stdout.String())
+	}
+}
+
+func withVersion(t *testing.T, version string) {
+	t.Helper()
+	old := build.Version
+	build.Version = version
+	t.Cleanup(func() { build.Version = old })
+}
+
+func writeUpdateState(t *testing.T, home, latest string) {
+	t.Helper()
+	dir := filepath.Join(home, ".config", "bohrium-skills-cli")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	data := []byte(`{"latest_version":"` + latest + `","checked_at":` + strconv.FormatInt(time.Now().Unix(), 10) + `}`)
+	if err := os.WriteFile(filepath.Join(dir, "update-state.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func clearNoticeEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"CI",
+		"BUILD_NUMBER",
+		"RUN_ID",
+		"BOHRIUM_SKILLS_CLI_NO_UPDATE_NOTIFIER",
+		"BOHRIUM_SKILLS_CLI_NO_SKILLS_NOTIFIER",
+	} {
+		t.Setenv(key, "")
+	}
+}

--- a/docs/npm-publish-test-record.md
+++ b/docs/npm-publish-test-record.md
@@ -1,0 +1,121 @@
+# bohrium-skills-cli npm 发布流程测试记录
+
+测试分支：`codex/npm-publish-test-flow`
+
+测试日期：2026-06-30
+
+## 目标
+
+在 fork 仓库上先验证 `bohrium-skills-cli` 的本地构建、临时安装、npm 打包与发布 dry-run 流程，确认后再向官方仓库提交 PR。
+
+## 环境状态
+
+- 当前 remote：`origin https://github.com/Grenzlinie/bohrium-skills.git`
+- GitHub CLI 状态：`gh auth status` 显示 `Grenzlinie` token 已失效，需要重新登录后才能 push / create PR / 查看 Actions。
+- npm 登录状态：`npm whoami` 返回 `ENEEDAUTH`，说明当前机器尚未登录 npm；真实发布前需要 `npm login` 或配置 CI `NPM_TOKEN`。
+
+## 本地 CLI 临时安装验证
+
+使用临时 HOME，不影响真实 `~/.agents/skills`、`~/.claude/skills`、`~/.codex/skills`。
+
+关键命令：
+
+```bash
+cd /Users/siyuliu/Desktop/bohrium-skills
+GOCACHE=/Users/siyuliu/Desktop/bohrium-skills/.gocache go build -o /tmp/bohrium-skills-cli ./cmd/bohrium-skills-cli
+TEST_HOME=$(mktemp -d /tmp/bohrium-skills-cli-home.XXXXXX)
+/tmp/bohrium-skills-cli list
+/tmp/bohrium-skills-cli install --home "$TEST_HOME" --json
+/tmp/bohrium-skills-cli status --home "$TEST_HOME" --json
+find "$TEST_HOME/.agents/skills" -maxdepth 1 -type d -name 'bohrium-*' | wc -l
+find "$TEST_HOME/.claude/skills" -maxdepth 1 -type d -name 'bohrium-*' | wc -l
+find "$TEST_HOME/.codex/skills" -maxdepth 1 -type d -name 'bohrium-*' | wc -l
+sed -n '1,12p' "$TEST_HOME/.agents/skills/bohrium-job/SKILL.md"
+/tmp/bohrium-skills-cli install --home "$TEST_HOME" --lang en --json
+/tmp/bohrium-skills-cli status --home "$TEST_HOME" --json
+```
+
+结果摘要：
+
+- `list` 输出 17 个 `bohrium-*` skills。
+- 默认 `install` 安装 `zh` 版本成功。
+- `status` 显示三处目标目录均存在，且 `skill_count=17`。
+- 三处目录计数均为 `17`。
+- `bohrium-job/SKILL.md` 在默认安装后显示中文标题 `# SKILL: Bohrium 任务 (Job) 管理`。
+- `install --lang en` 后 `status` 显示 `lang=en`，三处目录仍均为 `skill_count=17`。
+- `zh -> en` 覆盖产生 `backup_count=51`，符合 `17 skills × 3 target dirs`。
+
+## Go 测试与构建
+
+```bash
+GOCACHE=/Users/siyuliu/Desktop/bohrium-skills/.gocache go test ./...
+```
+
+结果：
+
+```text
+ok  	github.com/dptech-corp/bohrium-skills	(cached)
+ok  	github.com/dptech-corp/bohrium-skills/cmd/bohrium-skills-cli	(cached)
+?   	github.com/dptech-corp/bohrium-skills/internal/build	[no test files]
+ok  	github.com/dptech-corp/bohrium-skills/internal/syncer	(cached)
+ok  	github.com/dptech-corp/bohrium-skills/internal/updater	(cached)
+```
+
+```bash
+GOCACHE=/Users/siyuliu/Desktop/bohrium-skills/.gocache go build -o /tmp/bohrium-skills-cli-pr-test ./cmd/bohrium-skills-cli
+```
+
+结果：构建成功。
+
+## npm 打包与发布 dry-run
+
+```bash
+npm_config_cache=/tmp/bohrium-skills-npm-cache npm pack --dry-run
+```
+
+结果：
+
+```text
+npm notice 📦  bohrium-skills-cli@0.1.0
+npm notice filename: bohrium-skills-cli-0.1.0.tgz
+npm notice package size: 7.4 kB
+npm notice unpacked size: 17.9 kB
+npm notice total files: 5
+bohrium-skills-cli-0.1.0.tgz
+```
+
+```bash
+npm_config_cache=/tmp/bohrium-skills-npm-cache npm publish --dry-run
+```
+
+结果：
+
+```text
+npm notice 📦  bohrium-skills-cli@0.1.0
+npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access (dry-run)
++ bohrium-skills-cli@0.1.0
+```
+
+注意：dry-run 同时提示 `This command requires you to be logged in ... (dry-run)`，说明真实发布前仍需要 npm 登录或 CI token。
+
+## update --check 现状
+
+```bash
+/tmp/bohrium-skills-cli update --check --json
+```
+
+当前环境下失败原因是 npm registry 访问被本地代理/沙箱拦截：
+
+```text
+connect EPERM 127.0.0.1:7897
+```
+
+这是外部网络/代理问题，不影响本地安装、打包和 publish dry-run 验证。真实发布后需要在正常 npm registry 网络环境中复测。
+
+## 后续发布前检查项
+
+- 重新登录 GitHub CLI：`gh auth login -h github.com`
+- 登录 npm：`npm login`
+- 在 fork 仓库配置 `NPM_TOKEN` secret，用于 release workflow 的 `npm publish --provenance`
+- 推送测试分支并触发/观察 GitHub Actions
+- 若要真实发布 npm 包，确认包名 `bohrium-skills-cli` 在 npm registry 可用或有发布权限

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/dptech-corp/bohrium-skills
+
+go 1.23

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1,0 +1,3 @@
+package build
+
+var Version = "0.0.0-dev"

--- a/internal/skillsnotice/skillsnotice.go
+++ b/internal/skillsnotice/skillsnotice.go
@@ -1,0 +1,52 @@
+package skillsnotice
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync/atomic"
+
+	"github.com/dptech-corp/bohrium-skills/internal/syncer"
+	"github.com/dptech-corp/bohrium-skills/internal/updatecheck"
+)
+
+type StaleNotice struct {
+	Current string `json:"current"`
+	Target  string `json:"target"`
+}
+
+var pending atomic.Pointer[StaleNotice]
+
+func (s *StaleNotice) Message() string {
+	return fmt.Sprintf("bohrium-skills-cli skills %s out of sync with binary %s, run: bohrium-skills-cli update", s.Current, s.Target)
+}
+
+func SetPending(notice *StaleNotice) { pending.Store(notice) }
+
+func GetPending() *StaleNotice { return pending.Load() }
+
+func Check(currentVersion, configDir string) *StaleNotice {
+	if shouldSkip() {
+		return nil
+	}
+	state, readable, err := syncer.ReadState(configDir)
+	if err != nil || !readable || state == nil || strings.TrimSpace(state.Version) == "" {
+		return nil
+	}
+	current := normalizeVersion(state.Version)
+	target := normalizeVersion(currentVersion)
+	if current == target {
+		return nil
+	}
+	return &StaleNotice{Current: current, Target: target}
+}
+
+func shouldSkip() bool {
+	return updatecheck.IsCIEnv() || strings.TrimSpace(os.Getenv("BOHRIUM_SKILLS_CLI_NO_SKILLS_NOTIFIER")) != ""
+}
+
+func normalizeVersion(version string) string {
+	version = strings.TrimSpace(version)
+	version = strings.TrimPrefix(version, "v")
+	return strings.TrimPrefix(version, "V")
+}

--- a/internal/skillsnotice/skillsnotice_test.go
+++ b/internal/skillsnotice/skillsnotice_test.go
@@ -1,0 +1,62 @@
+package skillsnotice
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dptech-corp/bohrium-skills/internal/syncer"
+)
+
+func TestCheckReturnsNoticeWhenSkillsStateDrifts(t *testing.T) {
+	clearSkipEnv(t)
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".config", "bohrium-skills-cli")
+	if err := syncer.WriteState(configDir, syncer.State{Version: "0.1.0"}); err != nil {
+		t.Fatal(err)
+	}
+
+	notice := Check("0.2.0", configDir)
+	if notice == nil {
+		t.Fatal("Check returned nil, want stale notice")
+	}
+	if got, want := notice.Message(), "bohrium-skills-cli skills 0.1.0 out of sync with binary 0.2.0, run: bohrium-skills-cli update"; got != want {
+		t.Fatalf("Message() = %q, want %q", got, want)
+	}
+}
+
+func TestCheckSilentForInSyncMissingBadStateAndOptOut(t *testing.T) {
+	clearSkipEnv(t)
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".config", "bohrium-skills-cli")
+	if err := syncer.WriteState(configDir, syncer.State{Version: "0.2.0"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := Check("0.2.0", configDir); got != nil {
+		t.Fatalf("Check(in sync) = %+v, want nil", got)
+	}
+	if got := Check("0.2.0", filepath.Join(home, "missing")); got != nil {
+		t.Fatalf("Check(missing) = %+v, want nil", got)
+	}
+	badDir := filepath.Join(home, "bad")
+	if err := os.MkdirAll(badDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(badDir, syncer.StateFileName), []byte("{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := Check("0.2.0", badDir); got != nil {
+		t.Fatalf("Check(bad json) = %+v, want nil", got)
+	}
+	t.Setenv("BOHRIUM_SKILLS_CLI_NO_SKILLS_NOTIFIER", "1")
+	if got := Check("0.3.0", configDir); got != nil {
+		t.Fatalf("Check(opt-out) = %+v, want nil", got)
+	}
+}
+
+func clearSkipEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{"CI", "BUILD_NUMBER", "RUN_ID", "BOHRIUM_SKILLS_CLI_NO_SKILLS_NOTIFIER"} {
+		t.Setenv(key, "")
+	}
+}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -1,0 +1,515 @@
+package syncer
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const StateFileName = "skills-state.json"
+
+type State struct {
+	Version              string   `json:"version"`
+	Lang                 string   `json:"lang"`
+	OfficialSkills       []string `json:"official_skills"`
+	UpdatedSkills        []string `json:"updated_skills"`
+	AddedOfficialSkills  []string `json:"added_official_skills"`
+	SkippedDeletedSkills []string `json:"skipped_deleted_skills"`
+	TargetDirs           []string `json:"target_dirs"`
+	UpdatedAt            string   `json:"updated_at"`
+}
+
+type PlanInput struct {
+	Version        string
+	OfficialSkills []string
+	LocalSkills    []string
+	PreviousState  *State
+	StateReadable  bool
+	Force          bool
+}
+
+type Plan struct {
+	Version        string
+	OfficialSkills []string
+	ToUpdate       []string
+	Added          []string
+	SkippedDeleted []string
+}
+
+type SyncOptions struct {
+	Version   string
+	Lang      string
+	HomeDir   string
+	ConfigDir string
+	Targets   []string
+	SourceFS  fs.FS
+	Force     bool
+	Now       func() time.Time
+}
+
+type Result struct {
+	Action         string   `json:"action"`
+	Version        string   `json:"version"`
+	Lang           string   `json:"lang"`
+	Official       []string `json:"official"`
+	Updated        []string `json:"updated"`
+	Added          []string `json:"added"`
+	SkippedDeleted []string `json:"skipped_deleted"`
+	BackupCount    int      `json:"backup_count"`
+	TargetDirs     []string `json:"target_dirs"`
+	StatePath      string   `json:"state_path"`
+}
+
+type sourceSkill struct {
+	Name string
+	Path string
+}
+
+func PlanSync(input PlanInput) Plan {
+	official := uniqueSorted(input.OfficialSkills)
+	if input.Force {
+		return Plan{Version: input.Version, OfficialSkills: official, ToUpdate: official}
+	}
+
+	officialSet := toSet(official)
+	localOfficial := intersection(input.LocalSkills, officialSet)
+
+	var previousOfficial []string
+	if input.StateReadable && input.PreviousState != nil {
+		previousOfficial = input.PreviousState.OfficialSkills
+	}
+	previousSet := toSet(previousOfficial)
+
+	var added []string
+	for _, skill := range official {
+		if !previousSet[skill] {
+			added = append(added, skill)
+		}
+	}
+
+	updateSet := toSet(localOfficial)
+	for _, skill := range added {
+		updateSet[skill] = true
+	}
+	toUpdate := sortedKeys(updateSet)
+	updateSet = toSet(toUpdate)
+
+	var skipped []string
+	for _, skill := range official {
+		if !updateSet[skill] {
+			skipped = append(skipped, skill)
+		}
+	}
+
+	return Plan{
+		Version:        input.Version,
+		OfficialSkills: official,
+		ToUpdate:       toUpdate,
+		Added:          added,
+		SkippedDeleted: skipped,
+	}
+}
+
+func Sync(opts SyncOptions) (*Result, error) {
+	if opts.Lang == "" {
+		opts.Lang = "zh"
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	if opts.SourceFS == nil {
+		return nil, errors.New("source FS is nil")
+	}
+	home, err := resolveHome(opts.HomeDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(opts.Targets) == 0 {
+		opts.Targets = DefaultTargets(home)
+	}
+	configDir := opts.ConfigDir
+	if configDir == "" {
+		configDir = filepath.Join(home, ".config", "bohrium-skills-cli")
+	}
+
+	sources, err := listSourceSkills(opts.SourceFS, opts.Lang)
+	if err != nil {
+		return nil, err
+	}
+	sourceByName := map[string]sourceSkill{}
+	var official []string
+	for _, source := range sources {
+		official = append(official, source.Name)
+		sourceByName[source.Name] = source
+	}
+
+	state, readable, err := ReadState(configDir)
+	if err != nil {
+		readable = false
+	}
+	localSkills := listLocalSkills(opts.Targets)
+	plan := PlanSync(PlanInput{
+		Version:        opts.Version,
+		OfficialSkills: official,
+		LocalSkills:    localSkills,
+		PreviousState:  state,
+		StateReadable:  readable,
+		Force:          opts.Force,
+	})
+
+	result := &Result{
+		Action:         "synced",
+		Version:        opts.Version,
+		Lang:           opts.Lang,
+		Official:       nonNilStrings(plan.OfficialSkills),
+		Updated:        nonNilStrings(plan.ToUpdate),
+		Added:          nonNilStrings(plan.Added),
+		SkippedDeleted: nonNilStrings(plan.SkippedDeleted),
+		TargetDirs:     append([]string{}, opts.Targets...),
+		StatePath:      StatePath(configDir),
+	}
+
+	stamp := opts.Now().UTC().Format("20060102T150405Z")
+	for targetIndex, target := range opts.Targets {
+		for _, skillName := range plan.ToUpdate {
+			source := sourceByName[skillName]
+			backedUp, err := syncOneSkill(opts.SourceFS, source, target, configDir, stamp, targetIndex)
+			if err != nil {
+				return result, err
+			}
+			if backedUp {
+				result.BackupCount++
+			}
+		}
+	}
+
+	state = &State{
+		Version:              opts.Version,
+		Lang:                 opts.Lang,
+		OfficialSkills:       plan.OfficialSkills,
+		UpdatedSkills:        plan.ToUpdate,
+		AddedOfficialSkills:  plan.Added,
+		SkippedDeletedSkills: plan.SkippedDeleted,
+		TargetDirs:           opts.Targets,
+		UpdatedAt:            opts.Now().UTC().Format(time.RFC3339),
+	}
+	if err := WriteState(configDir, *state); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func DefaultTargets(home string) []string {
+	return []string{
+		filepath.Join(home, ".agents", "skills"),
+		filepath.Join(home, ".claude", "skills"),
+		filepath.Join(home, ".codex", "skills"),
+	}
+}
+
+func StatePath(configDir string) string {
+	return filepath.Join(configDir, StateFileName)
+}
+
+func ReadState(configDir string) (*State, bool, error) {
+	data, err := os.ReadFile(StatePath(configDir))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	var state State
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, false, err
+	}
+	ensureStateSlices(&state)
+	return &state, true, nil
+}
+
+func WriteState(configDir string, state State) error {
+	ensureStateSlices(&state)
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tmp, err := os.CreateTemp(configDir, ".skills-state-*.json")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, StatePath(configDir))
+}
+
+func listSourceSkills(sourceFS fs.FS, lang string) ([]sourceSkill, error) {
+	entries, err := fs.ReadDir(sourceFS, lang)
+	if err != nil {
+		return nil, err
+	}
+	var out []sourceSkill
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "bohrium-") {
+			continue
+		}
+		skillPath := filepath.ToSlash(filepath.Join(lang, entry.Name()))
+		data, err := fs.ReadFile(sourceFS, filepath.ToSlash(filepath.Join(skillPath, "SKILL.md")))
+		if err != nil {
+			return nil, err
+		}
+		name, err := frontmatterName(string(data))
+		if err != nil {
+			return nil, fmt.Errorf("%s/SKILL.md: %w", skillPath, err)
+		}
+		if name != entry.Name() {
+			return nil, fmt.Errorf("%s: frontmatter name %q does not match directory", skillPath, name)
+		}
+		out = append(out, sourceSkill{Name: name, Path: skillPath})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+func syncOneSkill(sourceFS fs.FS, source sourceSkill, targetRoot, configDir, stamp string, targetIndex int) (bool, error) {
+	if source.Name == "" || source.Path == "" {
+		return false, errors.New("empty source skill")
+	}
+	if err := os.MkdirAll(targetRoot, 0o755); err != nil {
+		return false, err
+	}
+	dest := filepath.Join(targetRoot, source.Name)
+	tmp, err := os.MkdirTemp(targetRoot, "."+source.Name+".tmp-")
+	if err != nil {
+		return false, err
+	}
+	tmpActive := true
+	defer func() {
+		if tmpActive {
+			_ = os.RemoveAll(tmp)
+		}
+	}()
+	if err := copySkillFromFS(sourceFS, source.Path, tmp); err != nil {
+		return false, err
+	}
+
+	backupMade := false
+	backupPath := filepath.Join(configDir, "backups", stamp, fmt.Sprintf("target-%d", targetIndex), source.Name)
+	if _, err := os.Stat(dest); err == nil {
+		if err := copyDir(dest, backupPath); err != nil {
+			return false, err
+		}
+		backupMade = true
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+
+	if err := os.RemoveAll(dest); err != nil {
+		return backupMade, err
+	}
+	if err := os.Rename(tmp, dest); err != nil {
+		if backupMade {
+			_ = copyDir(backupPath, dest)
+		}
+		return backupMade, err
+	}
+	tmpActive = false
+	return backupMade, nil
+}
+
+func copySkillFromFS(sourceFS fs.FS, sourcePath, destRoot string) error {
+	return fs.WalkDir(sourceFS, sourcePath, func(filePath string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(filepath.FromSlash(sourcePath), filepath.FromSlash(filePath))
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		dest := filepath.Join(destRoot, rel)
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return os.MkdirAll(dest, writableDirMode(info.Mode().Perm()))
+		}
+		data, err := fs.ReadFile(sourceFS, filePath)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return err
+		}
+		mode := info.Mode().Perm()
+		if mode == 0 {
+			mode = 0o644
+		}
+		return os.WriteFile(dest, data, mode)
+	})
+}
+
+func copyDir(src, dest string) error {
+	if err := os.RemoveAll(dest); err != nil {
+		return err
+	}
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		target := filepath.Join(dest, rel)
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return os.MkdirAll(target, writableDirMode(info.Mode().Perm()))
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, info.Mode().Perm())
+	})
+}
+
+func listLocalSkills(targets []string) []string {
+	seen := map[string]bool{}
+	for _, target := range targets {
+		entries, err := os.ReadDir(target)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				seen[entry.Name()] = true
+			}
+		}
+	}
+	return sortedKeys(seen)
+}
+
+func writableDirMode(mode os.FileMode) os.FileMode {
+	if mode == 0 {
+		return 0o755
+	}
+	return mode | 0o700
+}
+
+func resolveHome(home string) (string, error) {
+	if home != "" {
+		return home, nil
+	}
+	return os.UserHomeDir()
+}
+
+func frontmatterName(text string) (string, error) {
+	lines := strings.Split(text, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return "", fmt.Errorf("missing frontmatter")
+	}
+	for _, line := range lines[1:] {
+		line = strings.TrimSpace(line)
+		if line == "---" {
+			break
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok || strings.TrimSpace(key) != "name" {
+			continue
+		}
+		value = strings.Trim(strings.TrimSpace(value), `"'`)
+		if value == "" {
+			return "", fmt.Errorf("empty name")
+		}
+		return value, nil
+	}
+	return "", fmt.Errorf("frontmatter name not found")
+}
+
+func ensureStateSlices(state *State) {
+	if state.OfficialSkills == nil {
+		state.OfficialSkills = []string{}
+	}
+	if state.UpdatedSkills == nil {
+		state.UpdatedSkills = []string{}
+	}
+	if state.AddedOfficialSkills == nil {
+		state.AddedOfficialSkills = []string{}
+	}
+	if state.SkippedDeletedSkills == nil {
+		state.SkippedDeletedSkills = []string{}
+	}
+	if state.TargetDirs == nil {
+		state.TargetDirs = []string{}
+	}
+}
+
+func uniqueSorted(values []string) []string {
+	return sortedKeys(toSet(values))
+}
+
+func toSet(values []string) map[string]bool {
+	out := map[string]bool{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out[value] = true
+		}
+	}
+	return out
+}
+
+func intersection(values []string, allowed map[string]bool) []string {
+	out := map[string]bool{}
+	for _, value := range values {
+		if allowed[value] {
+			out[value] = true
+		}
+	}
+	return sortedKeys(out)
+}
+
+func sortedKeys(values map[string]bool) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func nonNilStrings(values []string) []string {
+	if values == nil {
+		return []string{}
+	}
+	return values
+}

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -1,0 +1,173 @@
+package syncer
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"testing/fstest"
+	"time"
+)
+
+func TestPlanSyncPreservesDeletedAndAddsNew(t *testing.T) {
+	got := PlanSync(PlanInput{
+		Version:        "1.2.3",
+		OfficialSkills: []string{"bohrium-job", "bohrium-node", "bohrium-new"},
+		LocalSkills:    []string{"bohrium-job", "custom-skill"},
+		PreviousState:  &State{OfficialSkills: []string{"bohrium-job", "bohrium-node"}},
+		StateReadable:  true,
+	})
+
+	assertStrings(t, got.ToUpdate, []string{"bohrium-job", "bohrium-new"})
+	assertStrings(t, got.Added, []string{"bohrium-new"})
+	assertStrings(t, got.SkippedDeleted, []string{"bohrium-node"})
+}
+
+func TestPlanSyncForceRestoresAllOfficial(t *testing.T) {
+	got := PlanSync(PlanInput{
+		Version:        "1.2.3",
+		OfficialSkills: []string{"bohrium-job", "bohrium-node"},
+		LocalSkills:    []string{"bohrium-job"},
+		PreviousState:  &State{OfficialSkills: []string{"bohrium-job", "bohrium-node"}},
+		StateReadable:  true,
+		Force:          true,
+	})
+
+	assertStrings(t, got.ToUpdate, []string{"bohrium-job", "bohrium-node"})
+	assertStrings(t, got.SkippedDeleted, []string{})
+}
+
+func TestSyncWritesThreeTargetsAndBacksUpExistingSkill(t *testing.T) {
+	home := t.TempDir()
+	targets := []string{
+		filepath.Join(home, ".agents", "skills"),
+		filepath.Join(home, ".claude", "skills"),
+		filepath.Join(home, ".codex", "skills"),
+	}
+	for _, target := range targets {
+		existing := filepath.Join(target, "bohrium-job")
+		if err := os.MkdirAll(existing, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(existing, "SKILL.md"), []byte("old"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	source := fstest.MapFS{
+		"zh/bohrium-job/SKILL.md":  {Data: []byte("---\nname: bohrium-job\n---\nnew\n")},
+		"zh/bohrium-job/script.py": {Data: []byte("print('ok')\n")},
+		"zh/bohrium-node/SKILL.md": {Data: []byte("---\nname: bohrium-node\n---\nnode\n")},
+	}
+	result, err := Sync(SyncOptions{
+		Version:   "1.2.3",
+		Lang:      "zh",
+		HomeDir:   home,
+		ConfigDir: filepath.Join(home, ".config", "bohrium-skills-cli"),
+		Targets:   targets,
+		SourceFS:  source,
+		Now:       fixedNow,
+	})
+	if err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+
+	assertStrings(t, result.Updated, []string{"bohrium-job", "bohrium-node"})
+	if got, want := result.BackupCount, 3; got != want {
+		t.Fatalf("BackupCount = %d, want %d", got, want)
+	}
+	for _, target := range targets {
+		got, err := os.ReadFile(filepath.Join(target, "bohrium-job", "SKILL.md"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(got), "new") {
+			t.Fatalf("%s was not updated: %q", target, string(got))
+		}
+		if _, err := os.Stat(filepath.Join(target, "bohrium-node", "SKILL.md")); err != nil {
+			t.Fatalf("new skill missing in %s: %v", target, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(home, ".config", "bohrium-skills-cli", "skills-state.json")); err != nil {
+		t.Fatalf("state file missing: %v", err)
+	}
+}
+
+func TestSyncPreservesDeletedOfficialSkillUnlessForced(t *testing.T) {
+	home := t.TempDir()
+	target := filepath.Join(home, ".agents", "skills")
+	source := fstest.MapFS{
+		"zh/bohrium-job/SKILL.md":  {Data: []byte("---\nname: bohrium-job\n---\njob\n")},
+		"zh/bohrium-node/SKILL.md": {Data: []byte("---\nname: bohrium-node\n---\nnode\n")},
+	}
+
+	first, err := Sync(SyncOptions{
+		Version:   "1.0.0",
+		Lang:      "zh",
+		HomeDir:   home,
+		ConfigDir: filepath.Join(home, ".config", "bohrium-skills-cli"),
+		Targets:   []string{target},
+		SourceFS:  source,
+		Now:       fixedNow,
+	})
+	if err != nil {
+		t.Fatalf("first Sync() error = %v", err)
+	}
+	assertStrings(t, first.Updated, []string{"bohrium-job", "bohrium-node"})
+	if err := os.RemoveAll(filepath.Join(target, "bohrium-node")); err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := Sync(SyncOptions{
+		Version:   "1.0.1",
+		Lang:      "zh",
+		HomeDir:   home,
+		ConfigDir: filepath.Join(home, ".config", "bohrium-skills-cli"),
+		Targets:   []string{target},
+		SourceFS:  source,
+		Now:       fixedNow,
+	})
+	if err != nil {
+		t.Fatalf("second Sync() error = %v", err)
+	}
+	assertStrings(t, second.SkippedDeleted, []string{"bohrium-node"})
+	if _, err := os.Stat(filepath.Join(target, "bohrium-node")); !os.IsNotExist(err) {
+		t.Fatalf("deleted skill restored without force, stat err = %v", err)
+	}
+
+	forced, err := Sync(SyncOptions{
+		Version:   "1.0.2",
+		Lang:      "zh",
+		HomeDir:   home,
+		ConfigDir: filepath.Join(home, ".config", "bohrium-skills-cli"),
+		Targets:   []string{target},
+		SourceFS:  source,
+		Force:     true,
+		Now:       fixedNow,
+	})
+	if err != nil {
+		t.Fatalf("forced Sync() error = %v", err)
+	}
+	assertStrings(t, forced.Updated, []string{"bohrium-job", "bohrium-node"})
+	if _, err := os.Stat(filepath.Join(target, "bohrium-node", "SKILL.md")); err != nil {
+		t.Fatalf("force did not restore deleted skill: %v", err)
+	}
+}
+
+func assertStrings(t *testing.T, got, want []string) {
+	t.Helper()
+	if got == nil {
+		got = []string{}
+	}
+	if want == nil {
+		want = []string{}
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+}
+
+func fixedNow() time.Time {
+	return time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+}

--- a/internal/updatecheck/updatecheck.go
+++ b/internal/updatecheck/updatecheck.go
@@ -1,0 +1,305 @@
+package updatecheck
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	defaultRegistryURL = "https://registry.npmjs.org/bohrium-skills-cli/latest"
+	cacheTTL           = 24 * time.Hour
+	fetchTimeout       = 5 * time.Second
+	StateFile          = "update-state.json"
+	maxBody            = 256 << 10
+)
+
+var (
+	RegistryURL   = defaultRegistryURL
+	DefaultClient *http.Client
+	pending       atomic.Pointer[UpdateInfo]
+)
+
+type UpdateInfo struct {
+	Current string `json:"current"`
+	Latest  string `json:"latest"`
+}
+
+func (u *UpdateInfo) Message() string {
+	return fmt.Sprintf("bohrium-skills-cli %s available, current %s, run: bohrium-skills-cli update", u.Latest, u.Current)
+}
+
+type updateState struct {
+	LatestVersion string `json:"latest_version"`
+	CheckedAt     int64  `json:"checked_at"`
+}
+
+type npmLatestResponse struct {
+	Version string `json:"version"`
+}
+
+func SetPending(info *UpdateInfo) { pending.Store(info) }
+
+func GetPending() *UpdateInfo { return pending.Load() }
+
+func CheckCached(currentVersion string) *UpdateInfo {
+	if shouldSkip(currentVersion) {
+		return nil
+	}
+	state, _ := loadState()
+	if state == nil || state.LatestVersion == "" {
+		return nil
+	}
+	if !IsNewer(state.LatestVersion, currentVersion) {
+		return nil
+	}
+	return &UpdateInfo{Current: normalizeVersion(currentVersion), Latest: normalizeVersion(state.LatestVersion)}
+}
+
+func NeedsRefresh(currentVersion string) bool {
+	if shouldSkip(currentVersion) {
+		return false
+	}
+	state, err := loadState()
+	if err != nil || state == nil {
+		return true
+	}
+	return time.Since(time.Unix(state.CheckedAt, 0)) >= cacheTTL
+}
+
+func RefreshCache(currentVersion string) {
+	if !NeedsRefresh(currentVersion) {
+		return
+	}
+	latest, err := FetchLatest()
+	if err != nil {
+		return
+	}
+	_ = saveState(&updateState{LatestVersion: latest, CheckedAt: time.Now().Unix()})
+}
+
+func FetchLatest() (string, error) {
+	client := DefaultClient
+	if client == nil {
+		client = &http.Client{Timeout: fetchTimeout}
+	}
+	resp, err := client.Get(RegistryURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("npm registry: HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
+	if err != nil {
+		return "", err
+	}
+	if len(body) > maxBody {
+		return "", fmt.Errorf("npm registry response exceeds %d bytes", maxBody)
+	}
+	var result npmLatestResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", err
+	}
+	version := strings.TrimSpace(result.Version)
+	if version == "" {
+		return "", fmt.Errorf("npm registry: empty version")
+	}
+	return version, nil
+}
+
+func IsCIEnv() bool {
+	for _, key := range []string{"CI", "BUILD_NUMBER", "RUN_ID"} {
+		if os.Getenv(key) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func IsRelease(version string) bool {
+	version = normalizeVersion(version)
+	if version == "" || version == "dev" || version == "DEV" || version == "0.0.0-dev" {
+		return false
+	}
+	if gitDescribePattern.MatchString(version) {
+		return false
+	}
+	return parseVersionDetail(version) != nil
+}
+
+func IsNewer(candidate, current string) bool {
+	ap := parseVersionDetail(candidate)
+	bp := parseVersionDetail(current)
+	if ap == nil {
+		return false
+	}
+	if bp == nil {
+		return true
+	}
+	for i := 0; i < 3; i++ {
+		if ap.core[i] > bp.core[i] {
+			return true
+		}
+		if ap.core[i] < bp.core[i] {
+			return false
+		}
+	}
+	return comparePrerelease(ap.prerelease, bp.prerelease) > 0
+}
+
+func shouldSkip(version string) bool {
+	if os.Getenv("BOHRIUM_SKILLS_CLI_NO_UPDATE_NOTIFIER") != "" {
+		return true
+	}
+	if IsCIEnv() {
+		return true
+	}
+	return !IsRelease(version)
+}
+
+func statePath() string {
+	return filepath.Join(configDir(), StateFile)
+}
+
+func configDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return filepath.Join(".", ".config", "bohrium-skills-cli")
+	}
+	return filepath.Join(home, ".config", "bohrium-skills-cli")
+}
+
+func loadState() (*updateState, error) {
+	data, err := os.ReadFile(statePath())
+	if err != nil {
+		return nil, err
+	}
+	var state updateState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, err
+	}
+	return &state, nil
+}
+
+func saveState(state *updateState) error {
+	dir := configDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".update-state-*.json")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, statePath())
+}
+
+var (
+	gitDescribePattern = regexp.MustCompile(`-\d+-g[0-9a-f]{7,}`)
+	versionPattern     = regexp.MustCompile(`^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$`)
+)
+
+type parsedVersion struct {
+	core       [3]int
+	prerelease string
+}
+
+func parseVersionDetail(version string) *parsedVersion {
+	version = normalizeVersion(version)
+	matches := versionPattern.FindStringSubmatch(version)
+	if matches == nil {
+		return nil
+	}
+	var parsed parsedVersion
+	for i := 0; i < 3; i++ {
+		n, err := strconv.Atoi(matches[i+1])
+		if err != nil {
+			return nil
+		}
+		parsed.core[i] = n
+	}
+	parsed.prerelease = matches[4]
+	if parsed.prerelease != "" && !validPrerelease.MatchString(parsed.prerelease) {
+		return nil
+	}
+	return &parsed
+}
+
+var validPrerelease = regexp.MustCompile(`^(?:0|[1-9]\d*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*$`)
+
+func comparePrerelease(a, b string) int {
+	if a == "" && b == "" {
+		return 0
+	}
+	if a == "" {
+		return 1
+	}
+	if b == "" {
+		return -1
+	}
+	ap := strings.Split(a, ".")
+	bp := strings.Split(b, ".")
+	for i := 0; i < len(ap) || i < len(bp); i++ {
+		if i >= len(ap) {
+			return -1
+		}
+		if i >= len(bp) {
+			return 1
+		}
+		cmp := comparePrereleaseIdentifier(ap[i], bp[i])
+		if cmp != 0 {
+			return cmp
+		}
+	}
+	return 0
+}
+
+func comparePrereleaseIdentifier(a, b string) int {
+	an, aErr := strconv.Atoi(a)
+	bn, bErr := strconv.Atoi(b)
+	switch {
+	case aErr == nil && bErr == nil:
+		if an < bn {
+			return -1
+		}
+		if an > bn {
+			return 1
+		}
+		return 0
+	case aErr == nil:
+		return -1
+	case bErr == nil:
+		return 1
+	default:
+		return strings.Compare(a, b)
+	}
+}
+
+func normalizeVersion(version string) string {
+	version = strings.TrimSpace(version)
+	version = strings.TrimPrefix(version, "v")
+	return strings.TrimPrefix(version, "V")
+}

--- a/internal/updatecheck/updatecheck_test.go
+++ b/internal/updatecheck/updatecheck_test.go
@@ -1,0 +1,127 @@
+package updatecheck
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCheckCachedReturnsNoticeForNewerCachedVersion(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	resetForTest(t)
+
+	if err := saveState(&updateState{LatestVersion: "0.2.0", CheckedAt: time.Now().Unix()}); err != nil {
+		t.Fatal(err)
+	}
+
+	info := CheckCached("0.1.0")
+	if info == nil {
+		t.Fatal("CheckCached returned nil, want update notice")
+	}
+	if got, want := info.Message(), "bohrium-skills-cli 0.2.0 available, current 0.1.0, run: bohrium-skills-cli update"; got != want {
+		t.Fatalf("Message() = %q, want %q", got, want)
+	}
+}
+
+func TestCheckCachedSkipsDevAndOptOut(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	resetForTest(t)
+	if err := saveState(&updateState{LatestVersion: "0.2.0", CheckedAt: time.Now().Unix()}); err != nil {
+		t.Fatal(err)
+	}
+	if got := CheckCached("0.0.0-dev"); got != nil {
+		t.Fatalf("CheckCached(dev) = %+v, want nil", got)
+	}
+	t.Setenv("BOHRIUM_SKILLS_CLI_NO_UPDATE_NOTIFIER", "1")
+	if got := CheckCached("0.1.0"); got != nil {
+		t.Fatalf("CheckCached(opt-out) = %+v, want nil", got)
+	}
+}
+
+func TestRefreshCacheUsesTTLAndFetchesExpiredCache(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	resetForTest(t)
+
+	requests := 0
+	DefaultClient = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		requests++
+		return response(http.StatusOK, `{"version":"0.3.0"}`), nil
+	})}
+
+	if err := saveState(&updateState{LatestVersion: "0.2.0", CheckedAt: time.Now().Unix()}); err != nil {
+		t.Fatal(err)
+	}
+	RefreshCache("0.1.0")
+	if requests != 0 {
+		t.Fatalf("fresh cache made %d requests, want 0", requests)
+	}
+
+	if err := saveState(&updateState{LatestVersion: "0.2.0", CheckedAt: time.Now().Add(-25 * time.Hour).Unix()}); err != nil {
+		t.Fatal(err)
+	}
+	RefreshCache("0.1.0")
+	if requests != 1 {
+		t.Fatalf("expired cache made %d requests, want 1", requests)
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".config", "bohrium-skills-cli", StateFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(data), `{"latest_version":"0.3.0"`; len(got) < len(want) || got[:len(want)] != want {
+		t.Fatalf("state = %s, want prefix %s", got, want)
+	}
+}
+
+func TestFetchLatestRejectsBadRegistryResponses(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		code int
+		body string
+	}{
+		{name: "http error", code: http.StatusInternalServerError, body: `{}`},
+		{name: "empty version", code: http.StatusOK, body: `{}`},
+		{name: "invalid json", code: http.StatusOK, body: `{`},
+		{name: "too large", code: http.StatusOK, body: strings.Repeat("x", maxBody+1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetForTest(t)
+			DefaultClient = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return response(tc.code, tc.body), nil
+			})}
+			if got, err := FetchLatest(); err == nil {
+				t.Fatalf("FetchLatest() = %q, nil error; want error", got)
+			}
+		})
+	}
+}
+
+func resetForTest(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{"CI", "BUILD_NUMBER", "RUN_ID", "BOHRIUM_SKILLS_CLI_NO_UPDATE_NOTIFIER"} {
+		t.Setenv(key, "")
+	}
+	SetPending(nil)
+	RegistryURL = defaultRegistryURL
+	DefaultClient = nil
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func response(code int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: code,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,0 +1,252 @@
+package updater
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dptech-corp/bohrium-skills/internal/updatecheck"
+)
+
+const (
+	NpmPackage = "bohrium-skills-cli"
+	RepoURL    = "https://github.com/dptech-corp/bohrium-skills"
+)
+
+type InstallMethod string
+
+const (
+	InstallNPM    InstallMethod = "npm"
+	InstallManual InstallMethod = "manual"
+)
+
+type Runner interface {
+	FetchLatest() (string, error)
+	DetectInstallMethod() InstallMethod
+	Install(version string) error
+	Sync(version string, force bool) error
+}
+
+type UpdateOptions struct {
+	CurrentVersion string
+	Force          bool
+	Check          bool
+	Runner         Runner
+}
+
+type Result struct {
+	Action          string        `json:"action"`
+	PreviousVersion string        `json:"previous_version"`
+	CurrentVersion  string        `json:"current_version"`
+	LatestVersion   string        `json:"latest_version"`
+	InstallMethod   InstallMethod `json:"install_method"`
+	URL             string        `json:"url,omitempty"`
+	Message         string        `json:"message"`
+	SkillsAction    string        `json:"skills_action,omitempty"`
+}
+
+type RealRunner struct {
+	SyncFunc func(version string, force bool) error
+	Timeout  time.Duration
+}
+
+type FakeRunner struct {
+	LatestVersion string
+	LatestErr     error
+	InstallFunc   func(version string) error
+	SyncFunc      func(version string, force bool) error
+	InstallMethod InstallMethod
+}
+
+func Update(opts UpdateOptions) (*Result, error) {
+	if opts.Runner == nil {
+		return nil, errors.New("update runner is nil")
+	}
+	cur := normalizeVersion(opts.CurrentVersion)
+	latestRaw, err := opts.Runner.FetchLatest()
+	if err != nil {
+		return nil, err
+	}
+	latest := normalizeVersion(latestRaw)
+	method := opts.Runner.DetectInstallMethod()
+	result := &Result{
+		PreviousVersion: cur,
+		CurrentVersion:  cur,
+		LatestVersion:   latest,
+		InstallMethod:   method,
+		URL:             RepoURL + "/releases/tag/v" + strings.TrimPrefix(latest, "v"),
+	}
+
+	newer := updatecheck.IsNewer(latest, cur)
+	if opts.Check {
+		if newer {
+			result.Action = "update_available"
+			result.Message = fmt.Sprintf("bohrium-skills-cli %s -> %s available", cur, latest)
+		} else {
+			result.Action = "already_up_to_date"
+			result.Message = fmt.Sprintf("bohrium-skills-cli %s is already up to date", cur)
+		}
+		return result, nil
+	}
+
+	if method != InstallNPM {
+		if err := opts.Runner.Sync(cur, opts.Force); err != nil {
+			return result, err
+		}
+		result.SkillsAction = "synced"
+		if newer {
+			result.Action = "manual_required"
+			result.Message = "automatic binary update unavailable; synced skills from the current binary"
+		} else {
+			result.Action = "already_up_to_date"
+			result.Message = "binary already up to date; synced skills"
+		}
+		return result, nil
+	}
+
+	targetVersion := cur
+	if newer || opts.Force {
+		if err := opts.Runner.Install(latest); err != nil {
+			return result, err
+		}
+		targetVersion = latest
+		result.Action = "updated"
+		result.CurrentVersion = latest
+		result.Message = fmt.Sprintf("bohrium-skills-cli updated from %s to %s", cur, latest)
+	} else {
+		result.Action = "already_up_to_date"
+		result.Message = fmt.Sprintf("bohrium-skills-cli %s is already up to date", cur)
+	}
+	if err := opts.Runner.Sync(targetVersion, opts.Force); err != nil {
+		return result, err
+	}
+	result.SkillsAction = "synced"
+	return result, nil
+}
+
+func (r RealRunner) FetchLatest() (string, error) {
+	return updatecheck.FetchLatest()
+}
+
+func (r RealRunner) DetectInstallMethod() InstallMethod {
+	exe, err := os.Executable()
+	if err != nil {
+		return InstallManual
+	}
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		resolved = exe
+	}
+	if strings.Contains(resolved, "node_modules") || strings.Contains(resolved, NpmPackage) {
+		return InstallNPM
+	}
+	return InstallManual
+}
+
+func (r RealRunner) Install(version string) error {
+	timeout := r.Timeout
+	if timeout == 0 {
+		timeout = 10 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "npm", "install", "-g", NpmPackage+"@"+version)
+	var combined bytes.Buffer
+	cmd.Stdout = &combined
+	cmd.Stderr = &combined
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("npm install failed: %w\n%s", err, strings.TrimSpace(combined.String()))
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("npm install timed out after %s", timeout)
+	}
+	return nil
+}
+
+func (r RealRunner) Sync(version string, force bool) error {
+	if r.SyncFunc == nil {
+		return errors.New("sync function is nil")
+	}
+	return r.SyncFunc(version, force)
+}
+
+func (f FakeRunner) FetchLatest() (string, error) {
+	if f.LatestErr != nil {
+		return "", f.LatestErr
+	}
+	return f.LatestVersion, nil
+}
+
+func (f FakeRunner) DetectInstallMethod() InstallMethod {
+	if f.InstallMethod == "" {
+		return InstallManual
+	}
+	return f.InstallMethod
+}
+
+func (f FakeRunner) Install(version string) error {
+	if f.InstallFunc == nil {
+		return nil
+	}
+	return f.InstallFunc(version)
+}
+
+func (f FakeRunner) Sync(version string, force bool) error {
+	if f.SyncFunc == nil {
+		return nil
+	}
+	return f.SyncFunc(version, force)
+}
+
+func IsNewer(candidate, current string) bool {
+	candidateParts := versionParts(candidate)
+	currentParts := versionParts(current)
+	for i := 0; i < len(candidateParts) || i < len(currentParts); i++ {
+		var c, cur int
+		if i < len(candidateParts) {
+			c = candidateParts[i]
+		}
+		if i < len(currentParts) {
+			cur = currentParts[i]
+		}
+		if c > cur {
+			return true
+		}
+		if c < cur {
+			return false
+		}
+	}
+	return false
+}
+
+func normalizeVersion(version string) string {
+	version = strings.TrimSpace(version)
+	version = strings.TrimPrefix(version, "v")
+	version = strings.TrimPrefix(version, "V")
+	return version
+}
+
+func versionParts(version string) []int {
+	version = normalizeVersion(version)
+	if index := strings.IndexAny(version, "+-"); index >= 0 {
+		version = version[:index]
+	}
+	raw := strings.Split(version, ".")
+	parts := make([]int, 0, len(raw))
+	for _, part := range raw {
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			parts = append(parts, 0)
+			continue
+		}
+		parts = append(parts, n)
+	}
+	return parts
+}

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,0 +1,72 @@
+package updater
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUpdateNPMInstallThenSyncsSkills(t *testing.T) {
+	var calls []string
+	runner := FakeRunner{
+		LatestVersion: "1.2.0",
+		InstallFunc: func(version string) error {
+			calls = append(calls, "install:"+version)
+			return nil
+		},
+		SyncFunc: func(version string, force bool) error {
+			calls = append(calls, "sync:"+version)
+			if force {
+				calls = append(calls, "force")
+			}
+			return nil
+		},
+		InstallMethod: InstallNPM,
+	}
+
+	result, err := Update(UpdateOptions{
+		CurrentVersion: "1.1.0",
+		Force:          true,
+		Runner:         runner,
+	})
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if result.Action != "updated" {
+		t.Fatalf("Action = %q, want updated", result.Action)
+	}
+	want := []string{"install:1.2.0", "sync:1.2.0", "force"}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls = %#v, want %#v", calls, want)
+	}
+}
+
+func TestUpdateCheckDoesNotInstallOrSync(t *testing.T) {
+	called := false
+	runner := FakeRunner{
+		LatestVersion: "1.2.0",
+		InstallFunc: func(version string) error {
+			called = true
+			return nil
+		},
+		SyncFunc: func(version string, force bool) error {
+			called = true
+			return nil
+		},
+		InstallMethod: InstallNPM,
+	}
+
+	result, err := Update(UpdateOptions{
+		CurrentVersion: "1.1.0",
+		Check:          true,
+		Runner:         runner,
+	})
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if result.Action != "update_available" {
+		t.Fatalf("Action = %q, want update_available", result.Action)
+	}
+	if called {
+		t.Fatal("check mode installed or synced")
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "bohrium-skills-cli",
+  "version": "0.1.0",
+  "description": "CLI installer and updater for the bundled Bohrium skills set.",
+  "license": "MIT",
+  "bin": {
+    "bohrium-skills-cli": "bin/bohrium-skills-cli"
+  },
+  "files": [
+    "bin/",
+    "scripts/",
+    "README.md",
+    "README_EN.md"
+  ],
+  "scripts": {
+    "postinstall": "node scripts/postinstall.js",
+    "postinstall:dry-run": "node scripts/postinstall.js --dry-run"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dptech-corp/bohrium-skills.git"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const https = require("https");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const repo = "https://github.com/dptech-corp/bohrium-skills";
+const pkg = require("../package.json");
+const dryRun = process.argv.includes("--dry-run");
+const skipSync = process.env.BOHRIUM_SKILLS_CLI_NO_POSTINSTALL_SYNC === "1";
+
+function platformName() {
+  const value = os.platform();
+  if (value === "darwin") return "darwin";
+  if (value === "linux") return "linux";
+  if (value === "win32") return "windows";
+  throw new Error(`unsupported platform: ${value}`);
+}
+
+function archName() {
+  const value = os.arch();
+  if (value === "x64") return "amd64";
+  if (value === "arm64") return "arm64";
+  throw new Error(`unsupported architecture: ${value}`);
+}
+
+function download(url, dest, redirects = 0) {
+  if (redirects > 5) {
+    throw new Error("too many redirects");
+  }
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, (res) => {
+      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        res.resume();
+        const next = new URL(res.headers.location, url).toString();
+        download(next, dest, redirects + 1).then(resolve, reject);
+        return;
+      }
+      if (res.statusCode !== 200) {
+        res.resume();
+        reject(new Error(`download failed with HTTP ${res.statusCode}: ${url}`));
+        return;
+      }
+      const file = fs.createWriteStream(dest, { mode: 0o755 });
+      res.pipe(file);
+      file.on("finish", () => file.close(resolve));
+      file.on("error", reject);
+    });
+    req.on("error", reject);
+  });
+}
+
+async function main() {
+  const goos = platformName();
+  const goarch = archName();
+  const exe = goos === "windows" ? ".exe" : "";
+  const asset = `bohrium-skills-cli_${goos}_${goarch}${exe}`;
+  const url = `${repo}/releases/download/v${pkg.version}/${asset}`;
+  const binDir = path.join(__dirname, "..", "bin");
+  const binPath = path.join(binDir, "bohrium-skills-cli");
+
+  if (dryRun) {
+    console.log(JSON.stringify({ url, binPath, skipSync }, null, 2));
+    return;
+  }
+
+  fs.mkdirSync(binDir, { recursive: true });
+  await download(url, binPath);
+  fs.chmodSync(binPath, 0o755);
+
+  if (skipSync) {
+    console.log("bohrium-skills-cli: postinstall skill sync skipped by BOHRIUM_SKILLS_CLI_NO_POSTINSTALL_SYNC=1");
+    return;
+  }
+
+  const result = spawnSync(binPath, ["install", "--lang", "zh", "--json"], {
+    stdio: "inherit",
+    env: process.env
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`bohrium-skills-cli install failed with exit code ${result.status}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(`bohrium-skills-cli postinstall failed: ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -6,7 +6,8 @@ const os = require("os");
 const path = require("path");
 const { spawnSync } = require("child_process");
 
-const repo = "https://github.com/dptech-corp/bohrium-skills";
+const defaultRepo = "https://github.com/dptech-corp/bohrium-skills";
+const repo = (process.env.BOHRIUM_SKILLS_CLI_RELEASE_REPO || defaultRepo).replace(/\/+$/, "");
 const pkg = require("../package.json");
 const dryRun = process.argv.includes("--dry-run");
 const skipSync = process.env.BOHRIUM_SKILLS_CLI_NO_POSTINSTALL_SYNC === "1";


### PR DESCRIPTION
## Summary

Add bohrium-skills-cli, an npm-distributed Go CLI that embeds the zh/en Bohrium skills and syncs them into ~/.agents/skills, ~/.claude/skills, and ~/.codex/skills.

## Highlights

- Add install/update/status/list/version commands
- Embed zh/en official bohrium-* skills and validate SKILL.md names
- Add safe sync with backups, state tracking, and force restore
- Add lark-cli-style update/skills notices with cache-backed checks
- Add npm postinstall downloader and release workflow with Trusted Publishing
- Document npm, GitHub Release, and test install flows

## Verification

- GOCACHE=/Users/siyuliu/Desktop/bohrium-skills/.gocache go test ./...
- npm_config_cache=/Users/siyuliu/Desktop/bohrium-skills/.npm-cache npm pack --dry-run
- Fork release/npm publish path tested with v0.1.0