### PR TITLE
docs(api): 补充 bohrium-job 提交任务组合流程接口

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -6327,6 +6327,346 @@
           }
         }
       }
+    },
+    "/openapi/v4/job_group/add": {
+      "post": {
+        "tags": [
+          "计算任务 (bohrium-job)"
+        ],
+        "summary": "创建任务组",
+        "description": "**提交任务流程第 1 步（可选）**。创建任务组（job group），用于把多个 job 归入同一组。已有任务组可跳过本步，直接在 `job/create` 传 `BohrGroupId`。\n\n> 提交一个任务需按顺序组合调用：① `job_group/add`（可选）→ ② `job/create`（拿上传凭证）→ ③ 上传输入文件到 tiefblue → ④ `job/add`（正式调度）。\n\n**已用正式 AccessKey 在 `https://open.bohrium.com` 验证通过。**",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "projectId"
+                ],
+                "properties": {
+                  "projectId": {
+                    "type": "integer",
+                    "description": "项目 ID"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "任务组名称"
+                  }
+                }
+              },
+              "example": {
+                "projectId": 123456,
+                "name": "my-batch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "groupId": {
+                          "type": "integer",
+                          "description": "新建任务组 ID，供后续 job/create 的 BohrGroupId 使用"
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "code": 0,
+                  "data": {
+                    "groupId": 7248822
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v4/job/create": {
+      "post": {
+        "tags": [
+          "计算任务 (bohrium-job)"
+        ],
+        "summary": "创建任务并获取上传凭证",
+        "description": "**提交任务流程第 2 步**。创建 job 记录并返回输入文件上传凭证。\n\n返回的 `token` + `storeHost` + `storePath` 用于**第 3 步**：把输入目录打包成 `input.zip` 后上传到 `{storeHost}/api/upload/binary`（小于 ~50MB 用二进制直传；更大走分片 `/api/upload/multipart/*`）。上传请求头：`Authorization: Bearer {token}`、`X-Storage-Param: {base64(JSON)}`（`{\"path\": objectKey, \"option\": {\"contentDisposition\": \"attachment; filename=\\\"input.zip\\\"\"}}`），其中 `objectKey = storePath + \"input.zip\"`。上传得到的 `objectKey` 即第 4 步 `job/add` 的 `ossPath`。\n\n**已用正式 AccessKey 验证通过（含 tiefblue 上传，返回 `{code:0}`）。**",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "projectId"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "任务名称"
+                  },
+                  "BohrGroupId": {
+                    "type": "integer",
+                    "description": "任务组 ID（第 1 步返回的 groupId）；不传或 0 时后端按需处理"
+                  },
+                  "projectId": {
+                    "type": "integer",
+                    "description": "项目 ID"
+                  }
+                }
+              },
+              "example": {
+                "name": "my-training-job",
+                "BohrGroupId": 7248822,
+                "projectId": 123456
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "jobId": {
+                          "type": "integer",
+                          "description": "新建任务 ID，供第 4 步 job/add 使用"
+                        },
+                        "jobGroupId": {
+                          "type": "integer",
+                          "description": "所属任务组 ID"
+                        },
+                        "storeHost": {
+                          "type": "string",
+                          "description": "tiefblue 存储主机，如 https://tiefblue.dp.tech"
+                        },
+                        "storePath": {
+                          "type": "string",
+                          "description": "输入文件存储前缀，如 511942/job/20403829/input/"
+                        },
+                        "token": {
+                          "type": "string",
+                          "description": "tiefblue 上传用的临时 JWT（放到上传请求的 Authorization: Bearer）"
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "code": 0,
+                  "data": {
+                    "jobId": 20403829,
+                    "jobGroupId": 7248822,
+                    "storeHost": "https://tiefblue.dp.tech",
+                    "storePath": "511942/job/20403829/input/",
+                    "token": "eyJhbGciOi..."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v4/job/add": {
+      "post": {
+        "tags": [
+          "计算任务 (bohrium-job)"
+        ],
+        "summary": "提交任务（正式调度）",
+        "description": "**提交任务流程第 4 步（最后一步）**。用第 2 步的 `jobId` 和第 3 步上传得到的 `ossPath` 提交任务，开始调度执行。\n\n**已用正式 AccessKey 在 `https://open.bohrium.com` 端到端验证通过**（返回 `{code:0, data:{jobId, bohrJobId, jobGroupId}}`，任务进入调度）。注意 `ossPath` 为**数组**、`jobType` 固定 `container`。",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "jobId",
+                  "jobType",
+                  "projectId",
+                  "scassType",
+                  "imageName",
+                  "cmd",
+                  "ossPath"
+                ],
+                "properties": {
+                  "jobId": {
+                    "type": "integer",
+                    "description": "第 2 步 job/create 返回的 jobId"
+                  },
+                  "jobType": {
+                    "type": "string",
+                    "description": "任务类型，固定为 container",
+                    "example": "container"
+                  },
+                  "projectId": {
+                    "type": "integer",
+                    "description": "项目 ID"
+                  },
+                  "jobGroupId": {
+                    "type": "integer",
+                    "description": "任务组 ID（第 1 步返回的 groupId）"
+                  },
+                  "jobName": {
+                    "type": "string",
+                    "description": "任务名称"
+                  },
+                  "scassType": {
+                    "type": "string",
+                    "description": "机器规格，如 c2_m4_cpu、c4_m15_1 * NVIDIA T4"
+                  },
+                  "imageName": {
+                    "type": "string",
+                    "description": "完整镜像地址，如 registry.dp.tech/dptech/deepmd-kit:3.1.1"
+                  },
+                  "cmd": {
+                    "type": "string",
+                    "description": "执行命令，用相对路径"
+                  },
+                  "platform": {
+                    "type": "string",
+                    "description": "计算平台，如 ali"
+                  },
+                  "ossPath": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "第 3 步上传得到的 objectKey 数组（storePath + input.zip）"
+                  },
+                  "inputFileType": {
+                    "type": "integer",
+                    "description": "输入文件类型，zip 输入固定 3"
+                  },
+                  "inputFileMethod": {
+                    "type": "integer",
+                    "description": "输入文件方式，固定 1"
+                  },
+                  "nnode": {
+                    "type": "integer",
+                    "description": "并行节点数，默认 1"
+                  },
+                  "diskSize": {
+                    "type": "integer",
+                    "description": "磁盘大小(GB)"
+                  },
+                  "logFiles": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "运行期可实时查看的日志文件"
+                  },
+                  "outFiles": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "需回收下载的结果文件，为空保留全部"
+                  },
+                  "datasetPath": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "挂载的数据集路径"
+                  },
+                  "maxRunTime": {
+                    "type": "integer",
+                    "description": "最大运行时间（分钟），超时自动终止"
+                  },
+                  "maxRescheduleTimes": {
+                    "type": "integer",
+                    "description": "异常中断后自动重试次数"
+                  }
+                }
+              },
+              "example": {
+                "jobId": 20403829,
+                "jobType": "container",
+                "projectId": 123456,
+                "jobGroupId": 7248822,
+                "jobName": "my-training-job",
+                "scassType": "c2_m4_cpu",
+                "imageName": "registry.dp.tech/dptech/ubuntu:20.04-py3.10",
+                "cmd": "bash run.sh",
+                "platform": "ali",
+                "ossPath": [
+                  "511942/job/20403829/input/input.zip"
+                ],
+                "inputFileType": 3,
+                "inputFileMethod": 1,
+                "nnode": 1
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "jobId": {
+                          "type": "integer",
+                          "description": "调度侧任务 ID（可用于 v4/job/kill、job/{id} 查询）"
+                        },
+                        "bohrJobId": {
+                          "type": "integer",
+                          "description": "Bohrium 任务 ID（即第 2 步的 jobId）"
+                        },
+                        "jobGroupId": {
+                          "type": "integer",
+                          "description": "调度侧任务组 ID"
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "code": 0,
+                  "data": {
+                    "jobId": 23055278,
+                    "bohrJobId": 20403829,
+                    "jobGroupId": 16378848
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/zh/bohrium-job/SKILL.md
+++ b/zh/bohrium-job/SKILL.md
@@ -347,6 +347,52 @@ requests.post(f"{BASE}/job_group/{job_group_id}/modify",
     json={"name": "new-group-name"})
 ```
 
+### 直接用 API 提交任务（不经 bohr CLI）
+
+`bohr job submit` 底层不是单个接口，而是**按顺序组合调用多个接口**：① 建任务组（可选）→ ② 建 job 拿上传凭证 → ③ 把输入 zip 上传到 tiefblue → ④ 正式提交调度。
+
+```python
+import os, json, base64, requests
+
+AK = os.environ["BOHR_ACCESS_KEY"]
+PROJECT_ID = int(os.environ["PROJECT_ID"])
+BASE = "https://open.bohrium.com/openapi/v4"
+H = {"Authorization": f"Bearer {AK}", "Content-Type": "application/json"}
+
+# ① 创建任务组（已有组可跳过，直接用其 groupId 作为 BohrGroupId）
+group_id = requests.post(f"{BASE}/job_group/add", headers=H,
+    json={"projectId": PROJECT_ID, "name": "my-batch"}).json()["data"]["groupId"]
+
+# ② 创建 job，拿上传凭证
+d = requests.post(f"{BASE}/job/create", headers=H,
+    json={"name": "my-job", "BohrGroupId": group_id, "projectId": PROJECT_ID}).json()["data"]
+job_id, store_host, store_path, token = d["jobId"], d["storeHost"], d["storePath"], d["token"]
+
+# ③ 把 input.zip 上传到 tiefblue（<~50MB 用二进制直传；更大走 /api/upload/multipart/*）
+object_key = store_path + "input.zip"
+xsp = base64.b64encode(json.dumps({
+    "path": object_key,
+    "option": {"contentDisposition": 'attachment; filename="input.zip"'},
+}).encode()).decode()
+with open("input.zip", "rb") as f:
+    requests.post(f"{store_host}/api/upload/binary",
+        headers={"Authorization": f"Bearer {token}", "X-Storage-Param": xsp},
+        data=f.read())
+
+# ④ 正式提交调度（jobType 固定 "container"，ossPath 为数组）
+resp = requests.post(f"{BASE}/job/add", headers=H, json={
+    "jobId": job_id, "jobType": "container", "projectId": PROJECT_ID,
+    "jobGroupId": group_id, "jobName": "my-job",
+    "scassType": "c2_m4_cpu",
+    "imageName": "registry.dp.tech/dptech/ubuntu:20.04-py3.10",
+    "cmd": "bash run.sh", "platform": "ali",
+    "ossPath": [object_key], "inputFileType": 3, "inputFileMethod": 1, "nnode": 1,
+}).json()
+print(resp)  # {"code": 0, "data": {"jobId": ..., "bohrJobId": ..., "jobGroupId": ...}}
+```
+
+> **验证状态（2026-07-16，正式 AK 于 open.bohrium.com）**：①②③④ 四步已端到端验证通过——④ `job/add` 返回 `{code:0, data:{jobId, bohrJobId, jobGroupId}}`，任务进入调度。用 `v4` 版本、`ossPath` 传**数组**、`jobType` 固定 `container`。返回的 `jobId` 可用于 `POST /openapi/v4/job/kill/{jobId}` 终止。
+
 ---
 
 ## 任务状态码


### PR DESCRIPTION
## 背景

「计算任务 (bohrium-job)」分组缺少**提交任务**的 API 说明。提交任务不是单个接口——是**组合调用多个接口**。本 PR 把这条组合流程补进 SSOT。

## 提交任务 = 4 步组合流程（v4）

1. `POST /openapi/v4/job_group/add` — 建任务组（可选）→ `{groupId}`
2. `POST /openapi/v4/job/create` — 建 job 拿上传凭证 → `{jobId, storeHost, storePath, token}`
3. 上传 `input.zip` 到 tiefblue：`POST {storeHost}/api/upload/binary`（`Authorization: Bearer {token}` + `X-Storage-Param`）
4. `POST /openapi/v4/job/add` — 正式提交调度 → `{jobId, bohrJobId, jobGroupId}`

## 改动

- `docs/api/openapi.json`：新增 3 个 v4 operation（都归到 `计算任务 (bohrium-job)` tag）。
- `zh/bohrium-job/SKILL.md`：在「API 补充」新增「直接用 API 提交任务」的 Python 示例。

## 用正式 AccessKey 在 open.bohrium.com 的端到端验证结果（全部通过）

| 步骤 | 结果 |
|------|------|
| ① `job_group/add` | ✅ `{code:0, data:{groupId}}` |
| ② `job/create` | ✅ 返回 `storeHost=https://tiefblue.dp.tech` / `storePath` / `token` |
| ③ tiefblue `POST /api/upload/binary` | ✅ `{code:0}` |
| ④ `job/add` | ✅ `{code:0, data:{jobId, bohrJobId, jobGroupId}}`，任务进入调度（验证用的测试任务已 `job/kill` 终止） |

## 注意事项

- 提交链路走 **v4**（BohriumCore）。
- 第 ④ 步 `ossPath` 为**数组**、`jobType` 固定 `"container"`。
- 返回的 `jobId` 可用于 `POST /openapi/v4/job/kill/{jobId}` 终止。
