### PR TITLE
docs(api): 建立模块认责与追溯体系 + openapi.json 规范化

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,45 @@
+# Bohrium OpenAPI — 代码/文档认责 (GitHub CODEOWNERS)
+#
+# 每个模块的接口契约以 zh|en/<skill>/SKILL.md 为准（openapi.json 由其派生）。
+# 在对应团队填入 @org/team 后，触及该模块 SKILL.md 的 PR 会自动请求其 review，
+# 从而把「谁改契约」和「谁负责」绑定。owners.yaml 保存联系方式/后端仓库等元信息。
+#
+# 语法: <path pattern>  <@user 或 @org/team>
+# 填写示例: /zh/bohrium-job/    @dptech-corp/compute-team
+
+# 全局兜底（OpenAPI 文档基建的维护者）
+/docs/api/            @dptech-corp/openapi-maintainers
+/tools/whoowns.py     @dptech-corp/openapi-maintainers
+/.github/CODEOWNERS   @dptech-corp/openapi-maintainers
+
+# 各模块契约文档 —— 请对应团队认领（把上面的占位团队替换为真实 @org/team）
+/zh/bohrium-dataset/         @dptech-corp/openapi-maintainers
+/en/bohrium-dataset/         @dptech-corp/openapi-maintainers
+/zh/bohrium-file/            @dptech-corp/openapi-maintainers
+/en/bohrium-file/            @dptech-corp/openapi-maintainers
+/zh/bohrium-job/             @dptech-corp/openapi-maintainers
+/en/bohrium-job/             @dptech-corp/openapi-maintainers
+/zh/bohrium-knowledge-base/  @dptech-corp/openapi-maintainers
+/en/bohrium-knowledge-base/  @dptech-corp/openapi-maintainers
+/zh/bohrium-lkm/             @dptech-corp/openapi-maintainers
+/en/bohrium-lkm/             @dptech-corp/openapi-maintainers
+/zh/bohrium-mentor/          @dptech-corp/openapi-maintainers
+/en/bohrium-mentor/          @dptech-corp/openapi-maintainers
+/zh/bohrium-node/            @dptech-corp/openapi-maintainers
+/en/bohrium-node/            @dptech-corp/openapi-maintainers
+/zh/bohrium-paper-search/    @dptech-corp/openapi-maintainers
+/en/bohrium-paper-search/    @dptech-corp/openapi-maintainers
+/zh/bohrium-pdf-parser/      @dptech-corp/openapi-maintainers
+/en/bohrium-pdf-parser/      @dptech-corp/openapi-maintainers
+/zh/bohrium-project/         @dptech-corp/openapi-maintainers
+/en/bohrium-project/         @dptech-corp/openapi-maintainers
+/zh/bohrium-image/           @dptech-corp/openapi-maintainers
+/en/bohrium-image/           @dptech-corp/openapi-maintainers
+/zh/bohrium-scholar-search/  @dptech-corp/openapi-maintainers
+/en/bohrium-scholar-search/  @dptech-corp/openapi-maintainers
+/zh/bohrium-sciencepedia/    @dptech-corp/openapi-maintainers
+/en/bohrium-sciencepedia/    @dptech-corp/openapi-maintainers
+/zh/bohrium-tools/           @dptech-corp/openapi-maintainers
+/en/bohrium-tools/           @dptech-corp/openapi-maintainers
+/zh/bohrium-web-search/      @dptech-corp/openapi-maintainers
+/en/bohrium-web-search/      @dptech-corp/openapi-maintainers

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ bin/bohrium-skills-cli.exe
 
 # Local reference checkout used for implementation notes
 references/
+# Reference source clones (contain other teams' source + production access keys — never commit)
+_ref/
+/bohrctl/

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -46,3 +46,15 @@
 - 导入频率：`每隔 3 小时`
 - 数据源：`Git 仓库` 连接 `dptech-corp/bohrium-skills`，文件路径 `docs/api/openapi.json`（或用该文件 raw URL + Basic Auth）
 - 导入模式：`智能合并`
+
+## 认责与追溯
+
+底层服务由各团队开发，本仓库集中维护契约文档。认责链路：
+
+- **契约归属**：每个模块的接口契约以 `zh|en/<skill>/SKILL.md` 为准（`openapi.json` 由其派生）。`.github/CODEOWNERS` 将触及某模块 SKILL.md 的 PR 自动指派给该团队 review —— 谁改契约、谁负责就此绑定。
+- **模块注册表**：`docs/api/owners.yaml` 记录每个模块的 `path_prefixes` 与 `team/owner/contact/service_repo/oncall`。各团队认领即填入自己的信息。
+- **从日志定位责任人**：`python3 tools/whoowns.py "<路径或日志行>"`，按最长前缀匹配得出模块、团队、联系方式与契约文档；`--json` 输出便于 Agent 调用。
+- **改动审计**：`git blame zh/<skill>/SKILL.md` 查最近改动人；PR #编号 追溯到具体变更与讨论。
+- **规范内嵌**：`openapi.json` 每个 tag 上带 `x-owner`（由 owners.yaml 注入），Agent 读 spec 即可知道归属。
+
+运维流程示例：拿到日志 → `whoowns.py` 定位模块与团队 → 按 owners.yaml 联系方式派单 → 团队改 SKILL.md → PR 经 CODEOWNERS review 合并 → Apifox 自动同步。

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.0.1",
   "info": {
     "title": "Bohrium OpenAPI",
-    "description": "Bohrium 平台对外 OpenAPI 的单一事实源（single source of truth）。\n\n本文档由仓库 `dptech-corp/bohrium-skills` 的 `docs/api/openapi.json` 维护，内容基于各 Skill（`zh/<skill>/SKILL.md`）中记录的真实接口生成；Apifox 定时从本仓库抓取并同步到 https://open.bohrium.com 。\n\n鉴权：所有接口使用 `Authorization: Bearer <BOHR_ACCESS_KEY>`。业务返回通常为 `{code, data, message}` 信封，`code==0` 成功，`code==2000` 未授权。\n\n计费端点在 operation 上以 `x-bohrium-price` 扩展标注机器可读价格，并在 description 末尾追加人类可读的「计费」行。\n\n说明：`bohrium-database`（SDK/CLI）与 `bohrium-sandbox`（CLI）不直接暴露 REST 端点，故本文档未收录其路径。",
-    "version": "2.0.0"
+    "description": "Bohrium 平台对外 OpenAPI 的单一事实源（single source of truth）。\n\n内容基于各 Skill（`zh/<skill>/SKILL.md`）中记录的真实接口、请求/响应示例生成；Apifox 定时从仓库 `dptech-corp/bohrium-skills` 的 `docs/api/openapi.json` 抓取并同步到 https://open.bohrium.com 。\n\n鉴权：所有接口使用 `Authorization: Bearer <BOHR_ACCESS_KEY>`。业务返回通常为 `{code, data, message}` 信封，`code==0` 成功，`code==2000` 未授权。\n\n计费端点带 `x-bohrium-price` 扩展并在 description 追加「计费」行；每个 tag 带 `x-owner` 标注模块归属（详见 `docs/api/owners.yaml` 与 `tools/whoowns.py`）。\n\n`bohrium-database`（SDK）与 `bohrium-sandbox`（CLI）不暴露 REST 端点，未收录。",
+    "version": "2.1.0"
   },
   "servers": [
     {
@@ -14,75 +14,257 @@
   "tags": [
     {
       "name": "数据集 (bohrium-dataset)",
-      "description": "数据集管理 — 创建、上传、下载、版本控制。免费。"
+      "x-owner": {
+        "module": "bohrium-dataset",
+        "skill_doc": "zh/bohrium-dataset/SKILL.md"
+      }
     },
     {
       "name": "文件盘 (bohrium-file)",
-      "description": "personal/share 盘文件管理 — 列出、上传、下载、移动、复制、删除。v1 用于 personal/share，v2 file 仅用于 appJob。免费。"
+      "x-owner": {
+        "module": "bohrium-file",
+        "skill_doc": "zh/bohrium-file/SKILL.md"
+      }
     },
     {
       "name": "计算任务 (bohrium-job)",
-      "description": "计算任务管理 — 提交、查询、终止、删除任务（提交主要经 bohr CLI）。任务运行按机时收费，价格见 Job 定价页。"
+      "x-owner": {
+        "module": "bohrium-job",
+        "skill_doc": "zh/bohrium-job/SKILL.md"
+      }
     },
     {
       "name": "知识库 (bohrium-knowledge-base)",
-      "description": "知识库管理 — 知识库/文件夹/文献/标签/笔记/召回/权限。网关转发至 literature-sage。免费（仅容量配额）。"
+      "x-owner": {
+        "module": "bohrium-knowledge-base",
+        "skill_doc": "zh/bohrium-knowledge-base/SKILL.md"
+      }
     },
     {
       "name": "大知识模型 (bohrium-lkm)",
-      "description": "LKM — 知识节点检索、推理链检索、论文知识图谱、追溯 claim 依据、批量节点水合、提交反馈。收费（定价中，待补充）。"
+      "x-owner": {
+        "module": "bohrium-lkm",
+        "skill_doc": "zh/bohrium-lkm/SKILL.md"
+      }
     },
     {
       "name": "AI 科学小导师 (bohrium-mentor)",
-      "description": "基于深度推理的科学问答（sigma-search，SSE 编排）。收费：创建会话 2 元/次。注意内部版本混用（sessions v4 / SSE v3 / history v4）。"
+      "x-owner": {
+        "module": "bohrium-mentor",
+        "skill_doc": "zh/bohrium-mentor/SKILL.md"
+      }
     },
     {
       "name": "开发节点 (bohrium-node)",
-      "description": "开发节点管理 — 创建、启停、删除容器/虚拟机。运行按机时收费，价格见 Node 定价页。"
+      "x-owner": {
+        "module": "bohrium-node",
+        "skill_doc": "zh/bohrium-node/SKILL.md"
+      }
     },
     {
       "name": "论文与专利搜索 (bohrium-paper-search)",
-      "description": "RAG 引擎关键词+语义检索。收费。响应可能为多行 JSON（流式，解析第一行）。"
+      "x-owner": {
+        "module": "bohrium-paper-search",
+        "skill_doc": "zh/bohrium-paper-search/SKILL.md"
+      }
     },
     {
       "name": "PDF 解析 (bohrium-pdf-parser)",
-      "description": "Uni-Parser — 提取文本、表格、图表、公式。收费：0.05 元/页（触发时扣）。figure 模块无权限时可能 403。"
+      "x-owner": {
+        "module": "bohrium-pdf-parser",
+        "skill_doc": "zh/bohrium-pdf-parser/SKILL.md"
+      }
     },
     {
       "name": "项目管理 (bohrium-project)",
-      "description": "项目管理 — 创建项目、管理成员、设置额度。免费（管理成本额度，非按调用计费）。"
+      "x-owner": {
+        "module": "bohrium-project",
+        "skill_doc": "zh/bohrium-project/SKILL.md"
+      }
     },
     {
       "name": "容器镜像 (bohrium-image)",
-      "description": "容器镜像管理 — 查询、拉取、创建、删除镜像。免费。镜像地址位于 registry.dp.tech / registry.bohrium.dp.tech。"
+      "x-owner": {
+        "module": "bohrium-image",
+        "skill_doc": "zh/bohrium-image/SKILL.md"
+      }
     },
     {
       "name": "学者搜索 (bohrium-scholar-search)",
-      "description": "学者搜索与画像 — 按姓名/机构检索，查看发文/引用/h-index/研究方向。免费。"
+      "x-owner": {
+        "module": "bohrium-scholar-search",
+        "skill_doc": "zh/bohrium-scholar-search/SKILL.md"
+      }
     },
     {
       "name": "科学百科 (bohrium-sciencepedia)",
-      "description": "科学百科 — 搜词条/关键词、浏览领域课程、看章节知识点、查主题知识图谱。免费（限时）。阅读链接指向 www.bohrium.com。"
+      "x-owner": {
+        "module": "bohrium-sciencepedia",
+        "skill_doc": "zh/bohrium-sciencepedia/SKILL.md"
+      }
     },
     {
       "name": "科学工具库 (bohrium-tools)",
-      "description": "科学工具库 — 按领域/子领域浏览、混合检索工具、查看详情与分类。免费。语言经 Content-Language 头或 body language 指定。"
+      "x-owner": {
+        "module": "bohrium-tools",
+        "skill_doc": "zh/bohrium-tools/SKILL.md"
+      }
     },
     {
       "name": "网页搜索 (bohrium-web-search)",
-      "description": "网页搜索 — 代理 searchapi.io 做开放互联网检索。免费。"
+      "x-owner": {
+        "module": "bohrium-web-search",
+        "skill_doc": "zh/bohrium-web-search/SKILL.md"
+      }
     }
   ],
   "paths": {
-    "/openapi/v2/ds/{id}": {
+    "/openapi/v2/ds/": {
       "get": {
         "tags": [
           "数据集 (bohrium-dataset)"
         ],
-        "summary": "数据集详情",
+        "summary": "列出数据集",
+        "description": "获取数据集列表。**重要**：路径带尾部斜杠 `/v2/ds/`，不要用 `/v2/ds/list`（会被 `/:id` 路由捕获报错）。",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "projectName": {
+                      "type": "string"
+                    },
+                    "creatorName": {
+                      "type": "string"
+                    },
+                    "updateTime": {
+                      "type": "string"
+                    },
+                    "desc": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "数据集 (bohrium-dataset)"
+        ],
+        "summary": "通过 API 创建数据集（程序化）",
+        "description": "程序化创建数据集，返回 tiefblue 上传路径。随后用 tiefblue 上传文件，再调用 `PUT /openapi/v2/ds/commit`。",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "projectId": {
+                    "type": "integer"
+                  },
+                  "identifier": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title",
+                  "projectId",
+                  "identifier"
+                ]
+              },
+              "example": {
+                "title": "my-dataset",
+                "projectId": 12345,
+                "identifier": "my-dataset"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "datasetId": {
+                      "type": "integer"
+                    },
+                    "tiefbluePath": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v2/ds/commit": {
+      "put": {
+        "tags": [
+          "数据集 (bohrium-dataset)"
+        ],
+        "summary": "提交数据集（上传文件后调用）",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "datasetId": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "datasetId"
+                ]
+              },
+              "example": {
+                "datasetId": 12345
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/ds/{dataset_id}": {
+      "get": {
+        "tags": [
+          "数据集 (bohrium-dataset)"
+        ],
+        "summary": "获取数据集详情",
         "parameters": [
           {
-            "name": "id",
+            "name": "dataset_id",
             "in": "path",
             "required": true,
             "schema": {
@@ -96,7 +278,24 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "versionId": {
+                      "type": "string"
+                    },
+                    "projectName": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -107,10 +306,10 @@
         "tags": [
           "数据集 (bohrium-dataset)"
         ],
-        "summary": "更新数据集信息",
+        "summary": "修改数据集信息",
         "parameters": [
           {
-            "name": "id",
+            "name": "dataset_id",
             "in": "path",
             "required": true,
             "schema": {
@@ -128,33 +327,29 @@
                     "type": "string"
                   }
                 }
+              },
+              "example": {
+                "title": "new-title"
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
     },
-    "/openapi/v2/ds/{id}/version": {
+    "/openapi/v2/ds/{dataset_id}/version": {
       "get": {
         "tags": [
           "数据集 (bohrium-dataset)"
         ],
-        "summary": "版本列表",
+        "summary": "获取数据集版本列表",
         "parameters": [
           {
-            "name": "id",
+            "name": "dataset_id",
             "in": "path",
             "required": true,
             "schema": {
@@ -168,7 +363,27 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "version": {
+                        "type": "string"
+                      },
+                      "totalCount": {
+                        "type": "integer"
+                      },
+                      "totalSize": {
+                        "type": "integer"
+                      },
+                      "downloadUri": {
+                        "type": "string"
+                      },
+                      "datasetPath": {
+                        "type": "string"
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -182,7 +397,7 @@
         "summary": "创建新版本",
         "parameters": [
           {
-            "name": "id",
+            "name": "dataset_id",
             "in": "path",
             "required": true,
             "schema": {
@@ -200,33 +415,29 @@
                     "type": "string"
                   }
                 }
+              },
+              "example": {
+                "versionDesc": "v2 update"
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
     },
-    "/openapi/v2/ds/{id}/version/{version_id}": {
+    "/openapi/v2/ds/{dataset_id}/version/{version_id}": {
       "get": {
         "tags": [
           "数据集 (bohrium-dataset)"
         ],
-        "summary": "版本详情",
+        "summary": "获取指定版本详情",
         "parameters": [
           {
-            "name": "id",
+            "name": "dataset_id",
             "in": "path",
             "required": true,
             "schema": {
@@ -244,14 +455,7 @@
         ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       },
@@ -259,10 +463,10 @@
         "tags": [
           "数据集 (bohrium-dataset)"
         ],
-        "summary": "删除版本",
+        "summary": "删除数据集版本",
         "parameters": [
           {
-            "name": "id",
+            "name": "dataset_id",
             "in": "path",
             "required": true,
             "schema": {
@@ -280,95 +484,7 @@
         ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/ds/": {
-      "post": {
-        "tags": [
-          "数据集 (bohrium-dataset)"
-        ],
-        "summary": "创建数据集（结尾斜杠必需）",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "title": {
-                    "type": "string"
-                  },
-                  "projectId": {
-                    "type": "string"
-                  },
-                  "identifier": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "title",
-                  "projectId"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/ds/commit": {
-      "put": {
-        "tags": [
-          "数据集 (bohrium-dataset)"
-        ],
-        "summary": "上传后提交",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "datasetId": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "datasetId"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -378,14 +494,14 @@
         "tags": [
           "数据集 (bohrium-dataset)"
         ],
-        "summary": "配额检查",
+        "summary": "检查配额",
         "parameters": [
           {
             "name": "projectId",
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
@@ -395,7 +511,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "boolean"
+                    },
+                    "limit": {
+                      "type": "integer"
+                    },
+                    "used": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "example": {
+                  "result": true,
+                  "limit": 30,
+                  "used": 5
                 }
               }
             }
@@ -408,20 +540,20 @@
         "tags": [
           "数据集 (bohrium-dataset)"
         ],
-        "summary": "获取上传 token",
+        "summary": "获取上传 Token（用于 tiefblue 上传）",
         "parameters": [
           {
             "name": "projectId",
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           },
           {
             "name": "path",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -433,7 +565,18 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "host": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -441,15 +584,15 @@
         }
       }
     },
-    "/openapi/v2/ds/{id}/permission": {
+    "/openapi/v2/ds/{dataset_id}/permission": {
       "get": {
         "tags": [
           "数据集 (bohrium-dataset)"
         ],
-        "summary": "数据集权限",
+        "summary": "查看数据集权限",
         "parameters": [
           {
-            "name": "id",
+            "name": "dataset_id",
             "in": "path",
             "required": true,
             "schema": {
@@ -459,14 +602,7 @@
         ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -476,17 +612,10 @@
         "tags": [
           "数据集 (bohrium-dataset)"
         ],
-        "summary": "关联项目",
+        "summary": "获取关联项目列表",
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -496,14 +625,28 @@
         "tags": [
           "文件盘 (bohrium-file)"
         ],
-        "summary": "解析当前身份 (user_id/orgId)",
+        "summary": "获取当前身份（AccessKey 对应用户）",
+        "description": "返回中使用 `data.user_id` 作为后续 `userId`；同时可获取 `orgId`。",
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "user_id": {
+                          "type": "integer"
+                        },
+                        "orgId": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -517,6 +660,7 @@
           "文件盘 (bohrium-file)"
         ],
         "summary": "列目录",
+        "description": "列出个人盘或项目共享盘目录。字段是 `prefix`，不是 `path`。若响应 `data.hasNext=true`，用返回的 `data.nextToken` 继续请求下一页。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -527,10 +671,10 @@
                     "type": "string"
                   },
                   "projectId": {
-                    "type": "string"
+                    "type": "integer"
                   },
                   "userId": {
-                    "type": "string"
+                    "type": "integer"
                   },
                   "dirSpace": {
                     "type": "string"
@@ -541,7 +685,20 @@
                   "nextToken": {
                     "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "prefix",
+                  "projectId",
+                  "userId"
+                ]
+              },
+              "example": {
+                "prefix": "personal/",
+                "projectId": 0,
+                "userId": 27071,
+                "dirSpace": "personal",
+                "maxObjects": 100,
+                "nextToken": ""
               }
             }
           }
@@ -552,7 +709,20 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "hasNext": {
+                          "type": "boolean"
+                        },
+                        "nextToken": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -565,7 +735,7 @@
         "tags": [
           "文件盘 (bohrium-file)"
         ],
-        "summary": "文件是否存在/状态",
+        "summary": "查看路径是否存在（文件信息）",
         "parameters": [
           {
             "name": "path",
@@ -578,30 +748,23 @@
           {
             "name": "projectId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           },
           {
             "name": "userId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -611,7 +774,7 @@
         "tags": [
           "文件盘 (bohrium-file)"
         ],
-        "summary": "文件元数据",
+        "summary": "获取文件元数据",
         "parameters": [
           {
             "name": "path",
@@ -624,30 +787,23 @@
           {
             "name": "projectId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           },
           {
             "name": "userId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -657,7 +813,8 @@
         "tags": [
           "文件盘 (bohrium-file)"
         ],
-        "summary": "下载（可能 302，需 -L）",
+        "summary": "下载文件",
+        "description": "可能重定向，curl 用 `-L`。",
         "parameters": [
           {
             "name": "path",
@@ -670,30 +827,23 @@
           {
             "name": "projectId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           },
           {
             "name": "userId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -714,26 +864,29 @@
                     "type": "string"
                   },
                   "projectId": {
-                    "type": "string"
+                    "type": "integer"
                   },
                   "userId": {
-                    "type": "string"
+                    "type": "integer"
                   }
-                }
+                },
+                "required": [
+                  "path",
+                  "projectId",
+                  "userId"
+                ]
+              },
+              "example": {
+                "path": "personal/new-folder",
+                "projectId": 0,
+                "userId": 27071
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -743,7 +896,8 @@
         "tags": [
           "文件盘 (bohrium-file)"
         ],
-        "summary": "移动/重命名",
+        "summary": "移动或重命名文件",
+        "description": "字段是 `sourcePath` 和 `destinationPath`，不是 `src`/`dst`。目录递归操作使用 `/mover`。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -755,22 +909,31 @@
                   },
                   "destinationPath": {
                     "type": "string"
+                  },
+                  "projectId": {
+                    "type": "integer"
+                  },
+                  "userId": {
+                    "type": "integer"
                   }
-                }
+                },
+                "required": [
+                  "sourcePath",
+                  "destinationPath"
+                ]
+              },
+              "example": {
+                "sourcePath": "personal/old.txt",
+                "destinationPath": "personal/new.txt",
+                "projectId": 0,
+                "userId": 27071
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -780,7 +943,7 @@
         "tags": [
           "文件盘 (bohrium-file)"
         ],
-        "summary": "移动（递归）",
+        "summary": "移动或重命名目录（递归）",
         "requestBody": {
           "content": {
             "application/json": {
@@ -792,22 +955,25 @@
                   },
                   "destinationPath": {
                     "type": "string"
+                  },
+                  "projectId": {
+                    "type": "integer"
+                  },
+                  "userId": {
+                    "type": "integer"
                   }
-                }
+                },
+                "required": [
+                  "sourcePath",
+                  "destinationPath"
+                ]
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -817,7 +983,8 @@
         "tags": [
           "文件盘 (bohrium-file)"
         ],
-        "summary": "复制",
+        "summary": "复制文件",
+        "description": "字段是 `sourcePath` 和 `destinationPath`。目录递归操作使用 `/copyr`。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -829,22 +996,31 @@
                   },
                   "destinationPath": {
                     "type": "string"
+                  },
+                  "projectId": {
+                    "type": "integer"
+                  },
+                  "userId": {
+                    "type": "integer"
                   }
-                }
+                },
+                "required": [
+                  "sourcePath",
+                  "destinationPath"
+                ]
+              },
+              "example": {
+                "sourcePath": "personal/source.txt",
+                "destinationPath": "personal/copy.txt",
+                "projectId": 0,
+                "userId": 27071
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -854,7 +1030,7 @@
         "tags": [
           "文件盘 (bohrium-file)"
         ],
-        "summary": "复制（递归）",
+        "summary": "复制目录（递归）",
         "requestBody": {
           "content": {
             "application/json": {
@@ -866,22 +1042,25 @@
                   },
                   "destinationPath": {
                     "type": "string"
+                  },
+                  "projectId": {
+                    "type": "integer"
+                  },
+                  "userId": {
+                    "type": "integer"
                   }
-                }
+                },
+                "required": [
+                  "sourcePath",
+                  "destinationPath"
+                ]
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -891,7 +1070,8 @@
         "tags": [
           "文件盘 (bohrium-file)"
         ],
-        "summary": "删除",
+        "summary": "删除文件",
+        "description": "目录递归删除使用 `/deleter/{path}`。",
         "parameters": [
           {
             "name": "path",
@@ -904,30 +1084,23 @@
           {
             "name": "projectId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           },
           {
             "name": "userId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -937,7 +1110,7 @@
         "tags": [
           "文件盘 (bohrium-file)"
         ],
-        "summary": "删除（递归）",
+        "summary": "删除目录（递归）",
         "parameters": [
           {
             "name": "path",
@@ -950,30 +1123,23 @@
           {
             "name": "projectId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           },
           {
             "name": "userId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -983,7 +1149,7 @@
         "tags": [
           "文件盘 (bohrium-file)"
         ],
-        "summary": "解压",
+        "summary": "解压文件",
         "requestBody": {
           "content": {
             "application/json": {
@@ -996,21 +1162,18 @@
                   "dirName": {
                     "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "filePath",
+                  "dirName"
+                ]
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -1020,28 +1183,29 @@
         "tags": [
           "文件盘 (bohrium-file)"
         ],
-        "summary": "获取上传凭证（推荐）",
+        "summary": "获取上传凭证（v2 两步上传第一步，推荐）",
+        "description": "向 open-platform 申请存储网关凭证，`path` 决定最终落到 personal 还是 share。返回 storage host + 上传凭证；第二步把二进制内容上传到返回的 `host`。",
         "parameters": [
           {
             "name": "projectId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           },
           {
             "name": "userId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           },
           {
             "name": "path",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -1053,7 +1217,34 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "Authorization": {
+                          "type": "string"
+                        },
+                        "X-Storage-Param": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "code": 0,
+                  "data": {
+                    "host": "https://tiefblue-nas.dp.tech",
+                    "Authorization": "Bearer ...",
+                    "X-Storage-Param": "..."
+                  }
                 }
               }
             }
@@ -1066,44 +1257,52 @@
         "tags": [
           "文件盘 (bohrium-file)"
         ],
-        "summary": "直接上传（返回 307，需 -L）",
-        "description": "Body 为二进制文件内容 (--data-binary)。",
+        "summary": "直接上传文件（v1 老接口）",
+        "description": "返回 307，curl 必须 `-L`（会返回 `307 Location: https://tiefblue-nas.dp.tech/api/upload/binary?...`）。请求体为二进制文件内容。",
         "parameters": [
           {
             "name": "projectId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           },
           {
             "name": "userId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           },
           {
             "name": "path",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
                 }
               }
             }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
           }
         }
       }
@@ -1114,6 +1313,7 @@
           "文件盘 (bohrium-file)"
         ],
         "summary": "列目录（仅 appJob 工作区）",
+        "description": "仅用于 appJob 工作区。`pathKey` 是 appJob id。当前上游不支持 `pathType: personal` 或 `share`（返回 `path type not found`）。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1124,61 +1324,55 @@
                     "type": "string"
                   },
                   "pathKey": {
-                    "type": "string"
+                    "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "pathType": "appJob",
+                "pathKey": 12345
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
     },
     "/openapi/v2/file/download": {
-      "get": {
+      "post": {
         "tags": [
           "文件盘 (bohrium-file)"
         ],
-        "summary": "下载（仅 appJob 工作区）",
-        "parameters": [
-          {
-            "name": "pathType",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "pathKey",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+        "summary": "下载文件（仅 appJob 工作区）",
+        "description": "仅用于 appJob 工作区。`pathKey` 是 appJob id。当前上游不支持 `pathType: personal` 或 `share`。",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "pathType": {
+                    "type": "string"
+                  },
+                  "pathKey": {
+                    "type": "integer"
+                  }
                 }
+              },
+              "example": {
+                "pathType": "appJob",
+                "pathKey": 12345
               }
             }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
           }
         }
       }
@@ -1188,7 +1382,8 @@
         "tags": [
           "计算任务 (bohrium-job)"
         ],
-        "summary": "任务列表",
+        "summary": "按状态过滤任务列表",
+        "description": "status: 0=等待, 1=运行中, 2=完成, 3=调度中, -1=失败。",
         "parameters": [
           {
             "name": "page",
@@ -1211,20 +1406,13 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -1234,7 +1422,8 @@
         "tags": [
           "计算任务 (bohrium-job)"
         ],
-        "summary": "任务配置（含文件 token）",
+        "summary": "查看任务配置（含文件访问 token）",
+        "description": "`token` + `host` 可用于 tiefblue 访问任务文件。",
         "parameters": [
           {
             "name": "job_id",
@@ -1251,7 +1440,27 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "state": {
+                      "type": "string"
+                    },
+                    "baseDir": {
+                      "type": "string"
+                    },
+                    "tempDir": {
+                      "type": "string"
+                    },
+                    "token": {
+                      "type": "string"
+                    },
+                    "host": {
+                      "type": "string"
+                    },
+                    "expires": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }
@@ -1264,7 +1473,7 @@
         "tags": [
           "计算任务 (bohrium-job)"
         ],
-        "summary": "任务快照",
+        "summary": "查看任务快照",
         "parameters": [
           {
             "name": "job_id",
@@ -1277,14 +1486,7 @@
         ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -1294,7 +1496,7 @@
         "tags": [
           "计算任务 (bohrium-job)"
         ],
-        "summary": "重命名任务",
+        "summary": "修改任务名",
         "parameters": [
           {
             "name": "job_id",
@@ -1314,21 +1516,20 @@
                   "name": {
                     "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "name"
+                ]
+              },
+              "example": {
+                "name": "new-name"
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -1338,7 +1539,7 @@
         "tags": [
           "计算任务 (bohrium-job)"
         ],
-        "summary": "重命名任务组",
+        "summary": "修改任务组名",
         "parameters": [
           {
             "name": "job_group_id",
@@ -1358,7 +1559,929 @@
                   "name": {
                     "type": "string"
                   }
+                },
+                "required": [
+                  "name"
+                ]
+              },
+              "example": {
+                "name": "new-group-name"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/project/list": {
+      "get": {
+        "tags": [
+          "项目管理 (bohrium-project)"
+        ],
+        "summary": "获取详细项目列表（含费用、成员数等）",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "totalCost": {
+                            "type": "number"
+                          },
+                          "monthCost": {
+                            "type": "number"
+                          },
+                          "userCount": {
+                            "type": "integer"
+                          },
+                          "projectRole": {
+                            "type": "integer"
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v2/project/lite_list": {
+      "get": {
+        "tags": [
+          "项目管理 (bohrium-project)"
+        ],
+        "summary": "精简项目列表（仅 id+name）",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/project/set_name": {
+      "post": {
+        "tags": [
+          "项目管理 (bohrium-project)"
+        ],
+        "summary": "重命名项目",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "projectId": {
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "projectId",
+                  "name"
+                ]
+              },
+              "example": {
+                "projectId": 12345,
+                "name": "new-name"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/project/set_cost_limit": {
+      "post": {
+        "tags": [
+          "项目管理 (bohrium-project)"
+        ],
+        "summary": "设置项目费用上限",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "projectId": {
+                    "type": "integer"
+                  },
+                  "costLimit": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "projectId",
+                  "costLimit"
+                ]
+              },
+              "example": {
+                "projectId": 12345,
+                "costLimit": 5000
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/project/{project_id}/users": {
+      "get": {
+        "tags": [
+          "项目管理 (bohrium-project)"
+        ],
+        "summary": "查看项目成员",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "userId": {
+                            "type": "integer"
+                          },
+                          "userName": {
+                            "type": "string"
+                          },
+                          "email": {
+                            "type": "string"
+                          },
+                          "projectRole": {
+                            "type": "integer"
+                          },
+                          "cost": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v2/project/add_user": {
+      "post": {
+        "tags": [
+          "项目管理 (bohrium-project)"
+        ],
+        "summary": "添加成员（通过 email）",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "projectId": {
+                    "type": "integer"
+                  },
+                  "email": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "projectId",
+                  "email"
+                ]
+              },
+              "example": {
+                "projectId": 12345,
+                "email": "user@example.com"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/project/del_user": {
+      "post": {
+        "tags": [
+          "项目管理 (bohrium-project)"
+        ],
+        "summary": "删除成员",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "projectId": {
+                    "type": "integer"
+                  },
+                  "userId": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "projectId",
+                  "userId"
+                ]
+              },
+              "example": {
+                "projectId": 12345,
+                "userId": 12345
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/project/manager/add": {
+      "post": {
+        "tags": [
+          "项目管理 (bohrium-project)"
+        ],
+        "summary": "添加管理员",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "projectId": {
+                    "type": "integer"
+                  },
+                  "userId": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "projectId",
+                  "userId"
+                ]
+              },
+              "example": {
+                "projectId": 12345,
+                "userId": 12345
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/project/manager/del": {
+      "post": {
+        "tags": [
+          "项目管理 (bohrium-project)"
+        ],
+        "summary": "删除管理员",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "projectId": {
+                    "type": "integer"
+                  },
+                  "userId": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "projectId",
+                  "userId"
+                ]
+              },
+              "example": {
+                "projectId": 12345,
+                "userId": 12345
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/project/{project_id}/recovery_user": {
+      "put": {
+        "tags": [
+          "项目管理 (bohrium-project)"
+        ],
+        "summary": "恢复已删除成员",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "userId": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "userId"
+                ]
+              },
+              "example": {
+                "userId": 12345
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/image/public/version/search": {
+      "get": {
+        "tags": [
+          "容器镜像 (bohrium-image)"
+        ],
+        "summary": "搜索公共镜像版本（关键词）",
+        "parameters": [
+          {
+            "name": "keyword",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "version": {
+                            "type": "string"
+                          },
+                          "resourceType": {
+                            "type": "string"
+                          },
+                          "size": {
+                            "type": "integer"
+                          },
+                          "url": {
+                            "type": "string"
+                          },
+                          "imageName": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v2/image/public": {
+      "get": {
+        "tags": [
+          "容器镜像 (bohrium-image)"
+        ],
+        "summary": "公共镜像分类列表",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/image/public/{image_id}/version": {
+      "get": {
+        "tags": [
+          "容器镜像 (bohrium-image)"
+        ],
+        "summary": "公共镜像版本列表",
+        "parameters": [
+          {
+            "name": "image_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/image/private": {
+      "get": {
+        "tags": [
+          "容器镜像 (bohrium-image)"
+        ],
+        "summary": "私有镜像列表",
+        "description": "必须传 `device` 和 `type` 参数。",
+        "parameters": [
+          {
+            "name": "device",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "url": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "buildType": {
+                            "type": "integer"
+                          },
+                          "creatorName": {
+                            "type": "string"
+                          },
+                          "projectName": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "容器镜像 (bohrium-image)"
+        ],
+        "summary": "创建私有镜像（Dockerfile 构建）",
+        "description": "`dockerfile` 字段必须是 base64 编码的字符串。",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "projectId": {
+                    "type": "integer"
+                  },
+                  "device": {
+                    "type": "string"
+                  },
+                  "desc": {
+                    "type": "string"
+                  },
+                  "buildType": {
+                    "type": "integer"
+                  },
+                  "dockerfile": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "projectId",
+                  "device",
+                  "buildType",
+                  "dockerfile"
+                ]
+              },
+              "example": {
+                "name": "my-image",
+                "projectId": 12345,
+                "device": "container",
+                "desc": "Custom training image",
+                "buildType": 1,
+                "dockerfile": "RlJPTSB1YnVudHU6MjIuMDQK"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/image/private/{image_id}": {
+      "get": {
+        "tags": [
+          "容器镜像 (bohrium-image)"
+        ],
+        "summary": "私有镜像详情",
+        "parameters": [
+          {
+            "name": "image_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "容器镜像 (bohrium-image)"
+        ],
+        "summary": "修改镜像描述",
+        "parameters": [
+          {
+            "name": "image_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "desc": {
+                    "type": "string"
+                  }
+                }
+              },
+              "example": {
+                "desc": "updated"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/image/dockerfile/check": {
+      "post": {
+        "tags": [
+          "容器镜像 (bohrium-image)"
+        ],
+        "summary": "检查 Dockerfile 合法性",
+        "description": "`dockerfile` 字段同样需要 base64 编码。",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "dockerfile": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "dockerfile"
+                ]
+              },
+              "example": {
+                "dockerfile": "RlJPTSB1YnVudHU6MjIuMDQK"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/image/last_used": {
+      "get": {
+        "tags": [
+          "容器镜像 (bohrium-image)"
+        ],
+        "summary": "获取上次使用的镜像",
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/image/{image_id}/share": {
+      "post": {
+        "tags": [
+          "容器镜像 (bohrium-image)"
+        ],
+        "summary": "分享镜像（项目成员可见）",
+        "parameters": [
+          {
+            "name": "image_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "容器镜像 (bohrium-image)"
+        ],
+        "summary": "取消分享镜像",
+        "parameters": [
+          {
+            "name": "image_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "device",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/node/add": {
+      "post": {
+        "tags": [
+          "开发节点 (bohrium-node)"
+        ],
+        "summary": "程序化创建节点（非交互式）",
+        "description": "从 `bohr image list --json` 获取 `imageId`；`machineConfig.value` 即 skuId。\n\n**计费**：按机时收费（元/小时），价格见 Node 定价页",
+        "x-bohrium-price": {
+          "billable": true,
+          "currency": "CNY",
+          "skill": "bohrium-node",
+          "unit": "小时",
+          "note": "开机后按机时收费，价格见 Node 定价页"
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "projectId": {
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "imageId": {
+                    "type": "integer"
+                  },
+                  "machineConfig": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "integer"
+                      },
+                      "value": {
+                        "type": "integer"
+                      },
+                      "label": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "diskSize": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "projectId",
+                  "name",
+                  "imageId",
+                  "machineConfig",
+                  "diskSize"
+                ]
+              },
+              "example": {
+                "projectId": 12345,
+                "name": "my-node",
+                "imageId": 67890,
+                "machineConfig": {
+                  "type": 0,
+                  "value": 388,
+                  "label": "c2_m4_cpu"
+                },
+                "diskSize": 20
               }
             }
           }
@@ -1369,10 +2492,314 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "machineId": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "code": 0,
+                  "data": {
+                    "machineId": 100001
+                  }
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/openapi/v2/node/resources": {
+      "get": {
+        "tags": [
+          "开发节点 (bohrium-node)"
+        ],
+        "summary": "查询可用机器资源",
+        "description": "其中 `value` 即 skuId，用于创建节点和查询价格。",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "disks": {
+                      "type": "array",
+                      "items": {
+                        "type": "integer"
+                      }
+                    },
+                    "cpuList": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "gpuList": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "disks": [
+                    20,
+                    40,
+                    80,
+                    100
+                  ],
+                  "cpuList": [],
+                  "gpuList": []
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v2/node/resources/price": {
+      "get": {
+        "tags": [
+          "开发节点 (bohrium-node)"
+        ],
+        "summary": "查询资源价格",
+        "description": "返回价格单位为元/小时。",
+        "parameters": [
+          {
+            "name": "skuId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "projectId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "price": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "data": {
+                    "price": "0.4"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v2/node/{machine_id}": {
+      "get": {
+        "tags": [
+          "开发节点 (bohrium-node)"
+        ],
+        "summary": "获取节点详情（含 SSH 密码）",
+        "parameters": [
+          {
+            "name": "machine_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "nodeId": {
+                      "type": "integer"
+                    },
+                    "nodeName": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "ip": {
+                      "type": "string"
+                    },
+                    "nodeUser": {
+                      "type": "string"
+                    },
+                    "nodePwd": {
+                      "type": "string"
+                    },
+                    "domainName": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v2/node/restart/{machine_id}": {
+      "post": {
+        "tags": [
+          "开发节点 (bohrium-node)"
+        ],
+        "summary": "重启节点（需先停止）",
+        "parameters": [
+          {
+            "name": "machine_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/node/modify/{machine_id}": {
+      "post": {
+        "tags": [
+          "开发节点 (bohrium-node)"
+        ],
+        "summary": "修改节点名称",
+        "parameters": [
+          {
+            "name": "machine_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              },
+              "example": {
+                "name": "new-name"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/node/ds": {
+      "get": {
+        "tags": [
+          "开发节点 (bohrium-node)"
+        ],
+        "summary": "查看节点绑定的数据集",
+        "parameters": [
+          {
+            "name": "nodeId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/node/ds/bind": {
+      "post": {
+        "tags": [
+          "开发节点 (bohrium-node)"
+        ],
+        "summary": "绑定数据集到节点",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "nodeId": {
+                    "type": "integer"
+                  },
+                  "datasetId": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "nodeId",
+                  "datasetId"
+                ]
+              },
+              "example": {
+                "nodeId": 100001,
+                "datasetId": 12345
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
           }
         }
       }
@@ -1401,7 +2828,19 @@
                   "privilege": {
                     "type": "integer"
                   }
-                }
+                },
+                "required": [
+                  "knowledgeBaseName",
+                  "cover",
+                  "introduction",
+                  "privilege"
+                ]
+              },
+              "example": {
+                "knowledgeBaseName": "My Knowledge Base",
+                "cover": "",
+                "introduction": "A collection of papers on molecular dynamics",
+                "privilege": 1
               }
             }
           }
@@ -1412,7 +2851,30 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "msg": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "code": 0,
+                  "data": {
+                    "id": 123,
+                    "msg": "Knowledge base created successfully."
+                  }
                 }
               }
             }
@@ -1456,7 +2918,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           },
           {
@@ -1464,7 +2926,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
@@ -1474,7 +2936,64 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "list": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "nodeId": {
+                                "type": "integer"
+                              },
+                              "introduction": {
+                                "type": "string"
+                              },
+                              "cover": {
+                                "type": "string"
+                              },
+                              "privilege": {
+                                "type": "integer"
+                              },
+                              "isZotero": {
+                                "type": "boolean"
+                              },
+                              "count": {
+                                "type": "integer"
+                              },
+                              "updateTime": {
+                                "type": "string"
+                              },
+                              "createTime": {
+                                "type": "string"
+                              },
+                              "source": {
+                                "type": "string"
+                              },
+                              "favoriteCount": {
+                                "type": "integer"
+                              },
+                              "sessionCount": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -1494,10 +3013,29 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "NodesId": {
+                  "knowledgeBaseName": {
                     "type": "string"
+                  },
+                  "cover": {
+                    "type": "string"
+                  },
+                  "introduction": {
+                    "type": "string"
+                  },
+                  "NodesId": {
+                    "type": "integer"
+                  },
+                  "privilege": {
+                    "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "knowledgeBaseName": "Updated Name",
+                "cover": "",
+                "introduction": "Updated introduction",
+                "NodesId": 456,
+                "privilege": 2
               }
             }
           }
@@ -1508,7 +3046,30 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "msg": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "code": 0,
+                  "data": {
+                    "id": 123,
+                    "msg": "Knowledge base updated successfully."
+                  }
                 }
               }
             }
@@ -1528,20 +3089,13 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -1552,16 +3106,27 @@
           "知识库 (bohrium-knowledge-base)"
         ],
         "summary": "发现公开知识库",
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "pageNum",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -1572,16 +3137,10 @@
           "知识库 (bohrium-knowledge-base)"
         ],
         "summary": "推荐知识库",
+        "description": "返回 data: {list, total, config_reason}",
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -1599,23 +3158,19 @@
                 "type": "object",
                 "properties": {
                   "nodesId": {
-                    "type": "string"
+                    "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "nodesId": 456
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       },
@@ -1623,17 +3178,28 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "我的收藏",
+        "summary": "查看我收藏的知识库",
+        "parameters": [
+          {
+            "name": "pageNum",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -1643,7 +3209,7 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "取消收藏",
+        "summary": "取消收藏知识库",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1651,23 +3217,19 @@
                 "type": "object",
                 "properties": {
                   "nodesId": {
-                    "type": "string"
+                    "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "nodesId": 456
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -1677,31 +3239,43 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "记录浏览",
+        "summary": "记录浏览历史",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
                 "properties": {
+                  "fileId": {
+                    "type": "integer"
+                  },
+                  "fileType": {
+                    "type": "integer"
+                  },
+                  "parentId": {
+                    "type": "integer"
+                  },
+                  "rootFolderId": {
+                    "type": "integer"
+                  },
                   "nodesId": {
-                    "type": "string"
+                    "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "fileId": 12345,
+                "fileType": 1,
+                "parentId": 456,
+                "rootFolderId": 456,
+                "nodesId": 456
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -1711,17 +3285,31 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "浏览历史",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+        "summary": "查询浏览历史",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "pageNum": {
+                    "type": "integer"
+                  },
+                  "pageSize": {
+                    "type": "integer"
+                  }
                 }
+              },
+              "example": {
+                "pageNum": 1,
+                "pageSize": 10
               }
             }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
           }
         }
       }
@@ -1731,17 +3319,31 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "搜索历史",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+        "summary": "查询搜索历史",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "pageNum": {
+                    "type": "integer"
+                  },
+                  "pageSize": {
+                    "type": "integer"
+                  }
                 }
+              },
+              "example": {
+                "pageNum": 1,
+                "pageSize": 10
               }
             }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
           }
         }
       }
@@ -1751,17 +3353,36 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "按名称搜索知识库",
+        "summary": "搜索知识库（按名称）",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
                 "properties": {
-                  "keyword": {
+                  "nodesId": {
+                    "type": "integer"
+                  },
+                  "searchText": {
                     "type": "string"
+                  },
+                  "searchType": {
+                    "type": "integer"
+                  },
+                  "pageNum": {
+                    "type": "integer"
+                  },
+                  "pageSize": {
+                    "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "nodesId": 456,
+                "searchText": "molecular dynamics",
+                "searchType": 0,
+                "pageNum": 1,
+                "pageSize": 10
               }
             }
           }
@@ -1772,7 +3393,42 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "total": {
+                          "type": "integer"
+                        },
+                        "folders": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "files": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "fileName": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -1785,14 +3441,50 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "根目录（知识库列表）",
+        "summary": "根目录列表（知识库列表）",
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "total": {
+                          "type": "integer"
+                        },
+                        "docCount": {
+                          "type": "integer"
+                        },
+                        "list": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "docCount": {
+                                "type": "integer"
+                              },
+                              "relationship": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -1805,14 +3497,14 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "子目录",
+        "summary": "子目录列表（一级）",
         "parameters": [
           {
             "name": "folderId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           },
           {
@@ -1838,7 +3530,92 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "path": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "nodesId": {
+                                "type": "integer"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "depth": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        },
+                        "folders": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "docCount": {
+                                "type": "integer"
+                              },
+                              "createdTime": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "files": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "nodesId": {
+                                "type": "integer"
+                              },
+                              "paperId": {
+                                "type": "string"
+                              },
+                              "md5": {
+                                "type": "string"
+                              },
+                              "enName": {
+                                "type": "string"
+                              },
+                              "zhName": {
+                                "type": "string"
+                              },
+                              "fileName": {
+                                "type": "string"
+                              },
+                              "authors": {
+                                "type": "string"
+                              },
+                              "date": {
+                                "type": "string"
+                              },
+                              "literatureType": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "fileCount": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -1851,17 +3628,21 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "目录树",
+        "summary": "目录树（递归树结构）",
+        "description": "递归树结构: {result: [{nodesId, name, subFolders: [...]}]}",
+        "parameters": [
+          {
+            "name": "folderId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -1871,17 +3652,20 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "含文献的文件树",
+        "summary": "文件树（含文献）",
+        "parameters": [
+          {
+            "name": "folderId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -1899,12 +3683,16 @@
                 "type": "object",
                 "properties": {
                   "parentId": {
-                    "type": "string"
+                    "type": "integer"
                   },
                   "folderName": {
                     "type": "string"
                   }
                 }
+              },
+              "example": {
+                "parentId": 456,
+                "folderName": "My Folder"
               }
             }
           }
@@ -1915,7 +3703,26 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "code": 0,
+                  "data": {
+                    "message": "..."
+                  }
                 }
               }
             }
@@ -1936,26 +3743,23 @@
                 "type": "object",
                 "properties": {
                   "nodesId": {
-                    "type": "string"
+                    "type": "integer"
                   },
                   "folderName": {
                     "type": "string"
                   }
                 }
+              },
+              "example": {
+                "nodesId": 789,
+                "folderName": "New Name"
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -1973,26 +3777,23 @@
                 "type": "object",
                 "properties": {
                   "sourceFolderId": {
-                    "type": "string"
+                    "type": "integer"
                   },
                   "targetFolderId": {
-                    "type": "string"
+                    "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "sourceFolderId": 789,
+                "targetFolderId": 456
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -2002,7 +3803,8 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "删除文件夹/知识库",
+        "summary": "删除文件夹 / 删除知识库（根 nodesId）",
+        "description": "删除文件夹。删除知识库等同于删除其根 nodesId（只有 Owner 角色 role=1 才能删除知识库根节点）。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2010,23 +3812,19 @@
                 "type": "object",
                 "properties": {
                   "nodesId": {
-                    "type": "string"
+                    "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "nodesId": 789
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -2041,9 +3839,9 @@
           {
             "name": "parentId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           },
           {
@@ -2067,7 +3865,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           },
           {
@@ -2075,7 +3873,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           },
           {
@@ -2089,14 +3887,7 @@
         ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -2111,7 +3902,7 @@
           {
             "name": "resourceId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -2123,7 +3914,108 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "enName": {
+                          "type": "string"
+                        },
+                        "zhName": {
+                          "type": "string"
+                        },
+                        "authors": {
+                          "type": "string"
+                        },
+                        "authorDetails": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "scholarId": {
+                                "type": "string"
+                              },
+                              "avatar": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "paperNums": {
+                                "type": "integer"
+                              },
+                              "citationNums": {
+                                "type": "integer"
+                              },
+                              "hIndex": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        },
+                        "doi": {
+                          "type": "string"
+                        },
+                        "enAbstract": {
+                          "type": "string"
+                        },
+                        "zhAbstract": {
+                          "type": "string"
+                        },
+                        "date": {
+                          "type": "string"
+                        },
+                        "fileName": {
+                          "type": "string"
+                        },
+                        "md5": {
+                          "type": "string"
+                        },
+                        "paperId": {
+                          "type": "string"
+                        },
+                        "publicationEnName": {
+                          "type": "string"
+                        },
+                        "literatureType": {
+                          "type": "string"
+                        },
+                        "openAccess": {
+                          "type": "boolean"
+                        },
+                        "existPDF": {
+                          "type": "boolean"
+                        },
+                        "summary": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "zhTitle": {
+                                "type": "string"
+                              },
+                              "content": {
+                                "type": "string"
+                              },
+                              "zhContent": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -2136,7 +4028,8 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "获取下载链接",
+        "summary": "文献下载链接",
+        "description": "返回每个 resource 的下载链接列表。注意参数名是 userResourceId，且为数组。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2146,24 +4039,22 @@
                   "userResourceId": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "integer"
                     }
                   }
                 }
+              },
+              "example": {
+                "userResourceId": [
+                  12345
+                ]
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -2174,11 +4065,12 @@
           "知识库 (bohrium-knowledge-base)"
         ],
         "summary": "获取上传凭证",
+        "description": "上传流程第一步：获取上传凭证 (host, path, token)。若 fileExist=true 则文件已存在，无需重复上传。",
         "parameters": [
           {
             "name": "fileName",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -2186,7 +4078,7 @@
           {
             "name": "md5",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -2194,15 +4086,15 @@
           {
             "name": "parentId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           },
           {
             "name": "size",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "integer"
             }
@@ -2214,7 +4106,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "fileExist": {
+                          "type": "boolean"
+                        },
+                        "host": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "token": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -2227,7 +4141,8 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "登记已上传文件",
+        "summary": "注册文件到知识库",
+        "description": "上传流程第三步：将上传完成的文件注册到知识库使其可见。code=230117 表示文件已存在。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2235,7 +4150,7 @@
                 "type": "object",
                 "properties": {
                   "parentId": {
-                    "type": "string"
+                    "type": "integer"
                   },
                   "fileName": {
                     "type": "string"
@@ -2250,6 +4165,13 @@
                     "type": "string"
                   }
                 }
+              },
+              "example": {
+                "parentId": 456,
+                "fileName": "paper.pdf",
+                "md5": "abc123",
+                "size": 102400,
+                "url": "path/to/uploaded/file"
               }
             }
           }
@@ -2260,7 +4182,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "example": {
+                  "code": 0
                 }
               }
             }
@@ -2273,7 +4203,8 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "编辑文献元数据",
+        "summary": "编辑文献信息",
+        "description": "name 和 abstract 字段需要传 JSON 字符串，如 '{\"cn\":\"...\",\"en\":\"...\"}'；authors 为 JSON 数组字符串。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2281,7 +4212,7 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "integer"
                   },
                   "name": {
                     "type": "string"
@@ -2291,22 +4222,62 @@
                   },
                   "authors": {
                     "type": "string"
+                  },
+                  "date": {
+                    "type": "string"
+                  },
+                  "journal": {
+                    "type": "string"
+                  },
+                  "abstract": {
+                    "type": "string"
+                  },
+                  "importance": {
+                    "type": "integer"
+                  },
+                  "recallable": {
+                    "type": "boolean"
+                  },
+                  "unableRecallEnMsg": {
+                    "type": "string"
+                  },
+                  "unableRecallZhMsg": {
+                    "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "id",
+                  "name",
+                  "doi",
+                  "authors",
+                  "date",
+                  "journal",
+                  "abstract",
+                  "importance",
+                  "recallable",
+                  "unableRecallEnMsg",
+                  "unableRecallZhMsg"
+                ]
+              },
+              "example": {
+                "id": 12345,
+                "name": "{\"cn\":\"中文标题\",\"en\":\"English Title\"}",
+                "doi": "10.1234/example",
+                "authors": "[\"Author A\",\"Author B\"]",
+                "date": "2024-01-15",
+                "journal": "Nature",
+                "abstract": "{\"cn\":\"中文摘要\",\"en\":\"English abstract\"}",
+                "importance": 1,
+                "recallable": true,
+                "unableRecallEnMsg": "",
+                "unableRecallZhMsg": ""
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -2324,26 +4295,19 @@
                 "type": "object",
                 "properties": {
                   "userResourceId": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
+                    "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "userResourceId": 12345
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -2361,29 +4325,23 @@
                 "type": "object",
                 "properties": {
                   "userResourceId": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
+                    "type": "integer"
                   },
                   "fileName": {
                     "type": "string"
                   }
                 }
+              },
+              "example": {
+                "userResourceId": 12345,
+                "fileName": "New Literature Name"
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -2403,27 +4361,27 @@
                   "fileNodesIdList": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "integer"
                     }
                   },
                   "folderNodesId": {
-                    "type": "string"
+                    "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "fileNodesIdList": [
+                  12345,
+                  12346
+                ],
+                "folderNodesId": 789
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -2433,7 +4391,7 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "内容搜索",
+        "summary": "文献内容搜索",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2444,12 +4402,17 @@
                     "type": "string"
                   },
                   "nodesId": {
-                    "type": "string"
+                    "type": "integer"
                   },
                   "knowledgeBaseId": {
-                    "type": "string"
+                    "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "queryContent": "molecular dynamics simulation",
+                "nodesId": 456,
+                "knowledgeBaseId": 123
               }
             }
           }
@@ -2460,7 +4423,40 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "total": {
+                          "type": "integer"
+                        },
+                        "Files": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "userResourceId": {
+                                "type": "integer"
+                              },
+                              "fileName": {
+                                "type": "string"
+                              },
+                              "content": {
+                                "type": "string"
+                              },
+                              "knowledgeBaseName": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -2473,7 +4469,8 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "按 userResourceId/enclosureId 取元信息",
+        "summary": "获取文献元信息",
+        "description": "按 userResourceId 获取文献元信息（md5/paperId/publicationId 等），也可用 enclosureId。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2481,26 +4478,22 @@
                 "type": "object",
                 "properties": {
                   "userResourceId": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
+                    "type": "integer"
+                  },
+                  "enclosureId": {
+                    "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "userResourceId": 12345
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -2510,7 +4503,7 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "文件夹下全部文献 ID",
+        "summary": "获取文件夹下所有文献 ID 列表",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2518,23 +4511,19 @@
                 "type": "object",
                 "properties": {
                   "parentId": {
-                    "type": "string"
+                    "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "parentId": 456
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -2544,27 +4533,20 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "单文件标签信息",
+        "summary": "单个文献的标签信息",
         "parameters": [
           {
             "name": "resourceId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -2575,16 +4557,27 @@
           "知识库 (bohrium-knowledge-base)"
         ],
         "summary": "上传记录",
+        "parameters": [
+          {
+            "name": "pageNum",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -2594,140 +4587,31 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "容量使用",
+        "summary": "容量信息",
+        "description": "返回 {remainingCapacity, totalCapacity, usedCapacity}",
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/knowledge/file/tag": {
-      "post": {
-        "tags": [
-          "知识库 (bohrium-knowledge-base)"
-        ],
-        "summary": "给文件打标签",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "tagId": {
-                    "type": "string"
-                  },
-                  "resourceId": {
-                    "type": "string"
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "remainingCapacity": {
+                          "type": "integer"
+                        },
+                        "totalCapacity": {
+                          "type": "integer"
+                        },
+                        "usedCapacity": {
+                          "type": "integer"
+                        }
+                      }
+                    }
                   }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "tags": [
-          "知识库 (bohrium-knowledge-base)"
-        ],
-        "summary": "标签统计",
-        "parameters": [
-          {
-            "name": "parentId",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "rootFolderId",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "query",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "keyword",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/knowledge/file/untag": {
-      "post": {
-        "tags": [
-          "知识库 (bohrium-knowledge-base)"
-        ],
-        "summary": "取消标签",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "tagId": {
-                    "type": "string"
-                  },
-                  "resourceId": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
                 }
               }
             }
@@ -2757,7 +4641,34 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "list": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "count": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -2779,6 +4690,9 @@
                     "type": "string"
                   }
                 }
+              },
+              "example": {
+                "name": "Machine Learning"
               }
             }
           }
@@ -2789,7 +4703,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -2808,26 +4738,23 @@
                 "type": "object",
                 "properties": {
                   "tagId": {
-                    "type": "string"
+                    "type": "integer"
                   },
                   "name": {
                     "type": "string"
                   }
                 }
+              },
+              "example": {
+                "tagId": 101,
+                "name": "Deep Learning"
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       },
@@ -2843,23 +4770,172 @@
                 "type": "object",
                 "properties": {
                   "tagId": {
-                    "type": "string"
+                    "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "tagId": 101
               }
             }
           }
         },
         "responses": {
           "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/openapi/v2/knowledge/file/tag": {
+      "post": {
+        "tags": [
+          "知识库 (bohrium-knowledge-base)"
+        ],
+        "summary": "给文献打标签",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "tagId": {
+                    "type": "integer"
+                  },
+                  "resourceId": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "example": {
+                "tagId": 101,
+                "resourceId": 12345
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "知识库 (bohrium-knowledge-base)"
+        ],
+        "summary": "文献标签统计",
+        "parameters": [
+          {
+            "name": "parentId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "rootFolderId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "keyword",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "allDocCount": {
+                          "type": "integer"
+                        },
+                        "noTagCount": {
+                          "type": "integer"
+                        },
+                        "tags": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "count": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/openapi/v2/knowledge/file/untag": {
+      "post": {
+        "tags": [
+          "知识库 (bohrium-knowledge-base)"
+        ],
+        "summary": "取消文献标签",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "tagId": {
+                    "type": "integer"
+                  },
+                  "resourceId": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "example": {
+                "tagId": 101,
+                "resourceId": 12345
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
           }
         }
       }
@@ -2874,9 +4950,9 @@
           {
             "name": "resourceId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
@@ -2886,7 +4962,20 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "note": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -2905,12 +4994,16 @@
                 "type": "object",
                 "properties": {
                   "resourceId": {
-                    "type": "string"
+                    "type": "integer"
                   },
                   "note": {
                     "type": "string"
                   }
                 }
+              },
+              "example": {
+                "resourceId": 12345,
+                "note": "This paper introduces a novel approach to..."
               }
             }
           }
@@ -2921,7 +5014,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "example": {
+                  "code": 0
                 }
               }
             }
@@ -2934,7 +5035,8 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "单篇文献切片",
+        "summary": "文献切片查看",
+        "description": "查看特定文献的解析切片结果。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2954,20 +5056,19 @@
                     "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "md5": "abc123...",
+                "paper_id": "paper_001",
+                "page_num": 1,
+                "page_size": 10
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -2977,7 +5078,8 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "指定文献内召回",
+        "summary": "指定文献召回",
+        "description": "在指定文献中进行语义召回。注意 upstream 字段名是 papers/text/k，不是 query/paperIds/topK。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2987,7 +5089,15 @@
                   "papers": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "object",
+                      "properties": {
+                        "paperId": {
+                          "type": "string"
+                        },
+                        "md5": {
+                          "type": "string"
+                        }
+                      }
                     }
                   },
                   "text": {
@@ -2997,20 +5107,27 @@
                     "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "papers": [
+                  {
+                    "paperId": "paper_001",
+                    "md5": ""
+                  },
+                  {
+                    "paperId": "",
+                    "md5": "abc123..."
+                  }
+                ],
+                "text": "molecular dynamics force field",
+                "k": 5
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -3020,7 +5137,8 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "知识库混合召回",
+        "summary": "混合召回（知识库级）",
+        "description": "在整个知识库中进行混合语义搜索。字段名用蛇形 (knowledge_base_id)；keywords 必填（不能为空字典），否则报 code=230606 keywords is required。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3028,7 +5146,7 @@
                 "type": "object",
                 "properties": {
                   "knowledge_base_id": {
-                    "type": "string"
+                    "type": "integer"
                   },
                   "text": {
                     "type": "string"
@@ -3037,11 +5155,20 @@
                     "type": "integer"
                   },
                   "keywords": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
+                    "type": "object"
                   }
+                },
+                "required": [
+                  "keywords"
+                ]
+              },
+              "example": {
+                "knowledge_base_id": 456,
+                "text": "deep potential energy surface",
+                "k": 10,
+                "keywords": {
+                  "deep potential": 1.0,
+                  "energy surface": 0.5
                 }
               }
             }
@@ -3049,14 +5176,7 @@
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -3067,26 +5187,20 @@
           "知识库 (bohrium-knowledge-base)"
         ],
         "summary": "权限列表",
+        "description": "返回 data: {privilege, shareMode, userList: [{id, role, isCreator, userName, ...}]}",
         "parameters": [
           {
             "name": "nodesId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -3104,7 +5218,7 @@
                 "type": "object",
                 "properties": {
                   "nodesId": {
-                    "type": "string"
+                    "type": "integer"
                   },
                   "privilege": {
                     "type": "integer"
@@ -3113,20 +5227,18 @@
                     "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "nodesId": 456,
+                "privilege": 1,
+                "shareMode": 1
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -3136,7 +5248,7 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "更新用户角色",
+        "summary": "更新用户权限",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3144,29 +5256,27 @@
                 "type": "object",
                 "properties": {
                   "nodesId": {
-                    "type": "string"
+                    "type": "integer"
                   },
                   "userId": {
-                    "type": "string"
+                    "type": "integer"
                   },
                   "role": {
                     "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "nodesId": 456,
+                "userId": 456,
+                "role": 67801
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       },
@@ -3174,7 +5284,7 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "移除用户角色",
+        "summary": "删除用户权限",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3182,26 +5292,23 @@
                 "type": "object",
                 "properties": {
                   "nodesId": {
-                    "type": "string"
+                    "type": "integer"
                   },
                   "userId": {
-                    "type": "string"
+                    "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "nodesId": 456,
+                "userId": 456
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -3212,6 +5319,7 @@
           "知识库 (bohrium-knowledge-base)"
         ],
         "summary": "批量添加读者",
+        "description": "可用 userList，或用 phones / emails / userNos 三选一。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3219,23 +5327,61 @@
                 "type": "object",
                 "properties": {
                   "nodesId": {
-                    "type": "string"
+                    "type": "integer"
+                  },
+                  "userList": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "role": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  },
+                  "phones": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "emails": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "userNos": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 }
+              },
+              "example": {
+                "nodesId": 456,
+                "userList": [
+                  {
+                    "id": 456,
+                    "role": 67801
+                  },
+                  {
+                    "id": 789,
+                    "role": 67801
+                  }
+                ]
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -3245,7 +5391,7 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "申请加入",
+        "summary": "申请加入知识库",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3253,23 +5399,19 @@
                 "type": "object",
                 "properties": {
                   "nodesId": {
-                    "type": "string"
+                    "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "nodesId": 456
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       },
@@ -3280,14 +5422,7 @@
         "summary": "查询加入申请",
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       },
@@ -3298,14 +5433,7 @@
         "summary": "审批加入申请",
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -3316,26 +5444,20 @@
           "知识库 (bohrium-knowledge-base)"
         ],
         "summary": "查询用户角色",
+        "description": "返回 data: {roles: [int, ...]}",
         "parameters": [
           {
             "name": "nodesId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -3345,17 +5467,10 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "已加入知识库（树）",
+        "summary": "当前用户加入的所有知识库（树形）",
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -3365,7 +5480,7 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "加入详情",
+        "summary": "查询某知识库加入详情",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3373,23 +5488,19 @@
                 "type": "object",
                 "properties": {
                   "nodesId": {
-                    "type": "string"
+                    "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "nodesId": 456
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -3399,7 +5510,7 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "退出知识库",
+        "summary": "主动退出知识库",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3407,23 +5518,19 @@
                 "type": "object",
                 "properties": {
                   "nodesId": {
-                    "type": "string"
+                    "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "nodesId": 456
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -3433,27 +5540,20 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "待处理加入申请",
+        "summary": "用户在某 KB 的待审申请",
         "parameters": [
           {
             "name": "nodesId",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -3463,17 +5563,10 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "我提交的加入申请",
+        "summary": "自己提交的加入申请列表",
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -3483,17 +5576,10 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "可审批的加入申请",
+        "summary": "自己可审批的加入申请",
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -3503,7 +5589,7 @@
         "tags": [
           "知识库 (bohrium-knowledge-base)"
         ],
-        "summary": "飞书机器人消息",
+        "summary": "飞书机器人发消息",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3511,767 +5597,23 @@
                 "type": "object",
                 "properties": {
                   "type": {
-                    "type": "integer"
+                    "type": "string"
                   },
                   "msg": {
                     "type": "string"
                   }
                 }
+              },
+              "example": {
+                "type": "text",
+                "msg": "hello"
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v1/lkm/search": {
-      "post": {
-        "tags": [
-          "大知识模型 (bohrium-lkm)"
-        ],
-        "summary": "检索 claim/question/abstract",
-        "description": "**计费**：按调用计费，实际费用以账单为准",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "query": {
-                    "type": "string"
-                  },
-                  "keywords": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "retrieval_mode": {
-                    "type": "string"
-                  },
-                  "sort_by": {
-                    "type": "string"
-                  },
-                  "scopes": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "filters": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "reasoning_only": {
-                    "type": "boolean"
-                  },
-                  "offset": {
-                    "type": "integer"
-                  },
-                  "limit": {
-                    "type": "integer"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-bohrium-price": {
-          "billable": true,
-          "currency": "CNY",
-          "skill": "bohrium-lkm",
-          "note": "按调用计费，实际费用以账单为准"
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v1/lkm/reasoning/search": {
-      "post": {
-        "tags": [
-          "大知识模型 (bohrium-lkm)"
-        ],
-        "summary": "推理链检索",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "query": {
-                    "type": "string"
-                  },
-                  "keywords": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "format": {
-                    "type": "string"
-                  },
-                  "filters": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "offset": {
-                    "type": "integer"
-                  },
-                  "limit": {
-                    "type": "integer"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v1/lkm/papers/graph": {
-      "post": {
-        "tags": [
-          "大知识模型 (bohrium-lkm)"
-        ],
-        "summary": "论文级知识图谱",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "package_id": {
-                    "type": "string"
-                  },
-                  "paper_id": {
-                    "type": "string"
-                  },
-                  "doi": {
-                    "type": "string"
-                  },
-                  "title": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v1/lkm/claims/{id}/reasoning": {
-      "get": {
-        "tags": [
-          "大知识模型 (bohrium-lkm)"
-        ],
-        "summary": "单 claim 推理链",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "format",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "max_chains",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "sort_by",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v1/lkm/variables/batch": {
-      "post": {
-        "tags": [
-          "大知识模型 (bohrium-lkm)"
-        ],
-        "summary": "批量水合节点",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "ids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v1/lkm/feedback": {
-      "post": {
-        "tags": [
-          "大知识模型 (bohrium-lkm)"
-        ],
-        "summary": "提交反馈",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "integer"
-                  },
-                  "content": {
-                    "type": "boolean"
-                  },
-                  "gcn_id": {
-                    "type": "string"
-                  },
-                  "paper_metadata_id": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/sigma-search/api/v4/ai_search/sessions": {
-      "post": {
-        "tags": [
-          "AI 科学小导师 (bohrium-mentor)"
-        ],
-        "summary": "创建会话，返回 sessionId",
-        "description": "**计费**：2 元/次 或 200 光子/次（创建会话时收取）",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "query": {
-                    "type": "string"
-                  },
-                  "model": {
-                    "type": "string"
-                  },
-                  "discipline": {
-                    "type": "string"
-                  },
-                  "scene": {
-                    "type": "string"
-                  },
-                  "journal_type": {
-                    "type": "string"
-                  },
-                  "snp_version": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-bohrium-price": {
-          "billable": true,
-          "currency": "CNY",
-          "skill": "bohrium-mentor",
-          "items": [
-            {
-              "amount": 2,
-              "unit": "次"
-            }
-          ],
-          "note": "2 元/次 或 200 光子/次"
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/sigma-search/api/v3/sse/ai_search/v1/{sessionId}/stream": {
-      "get": {
-        "tags": [
-          "AI 科学小导师 (bohrium-mentor)"
-        ],
-        "summary": "订阅 SSE 流",
-        "parameters": [
-          {
-            "name": "sessionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/sigma-search/api/v4/ai_search/sessions/{sessionId}": {
-      "get": {
-        "tags": [
-          "AI 科学小导师 (bohrium-mentor)"
-        ],
-        "summary": "会话元数据",
-        "parameters": [
-          {
-            "name": "sessionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/sigma-search/api/v4/{sessionId}/history": {
-      "get": {
-        "tags": [
-          "AI 科学小导师 (bohrium-mentor)"
-        ],
-        "summary": "会话历史（断线恢复）",
-        "parameters": [
-          {
-            "name": "sessionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/node/add": {
-      "post": {
-        "tags": [
-          "开发节点 (bohrium-node)"
-        ],
-        "summary": "创建节点（非交互）",
-        "description": "**计费**：按机时收费（元/小时），价格见 Node 定价页",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "projectId": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "imageId": {
-                    "type": "string"
-                  },
-                  "machineConfig": {
-                    "type": "string"
-                  },
-                  "diskSize": {
-                    "type": "integer"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-bohrium-price": {
-          "billable": true,
-          "currency": "CNY",
-          "skill": "bohrium-node",
-          "unit": "小时",
-          "note": "开机后按机时收费，价格见 Node 定价页"
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/node/resources": {
-      "get": {
-        "tags": [
-          "开发节点 (bohrium-node)"
-        ],
-        "summary": "可用机型资源",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/node/resources/price": {
-      "get": {
-        "tags": [
-          "开发节点 (bohrium-node)"
-        ],
-        "summary": "资源价格（元/小时）",
-        "parameters": [
-          {
-            "name": "skuId",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "projectId",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/node/{machine_id}": {
-      "get": {
-        "tags": [
-          "开发节点 (bohrium-node)"
-        ],
-        "summary": "节点详情（含 SSH 密码）",
-        "parameters": [
-          {
-            "name": "machine_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/node/restart/{machine_id}": {
-      "post": {
-        "tags": [
-          "开发节点 (bohrium-node)"
-        ],
-        "summary": "重启节点",
-        "parameters": [
-          {
-            "name": "machine_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/node/modify/{machine_id}": {
-      "post": {
-        "tags": [
-          "开发节点 (bohrium-node)"
-        ],
-        "summary": "重命名节点",
-        "parameters": [
-          {
-            "name": "machine_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/node/ds": {
-      "get": {
-        "tags": [
-          "开发节点 (bohrium-node)"
-        ],
-        "summary": "查看绑定的数据集",
-        "parameters": [
-          {
-            "name": "nodeId",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/node/ds/bind": {
-      "post": {
-        "tags": [
-          "开发节点 (bohrium-node)"
-        ],
-        "summary": "绑定数据集",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "nodeId": {
-                    "type": "string"
-                  },
-                  "datasetId": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }
@@ -4281,8 +5623,8 @@
         "tags": [
           "论文与专利搜索 (bohrium-paper-search)"
         ],
-        "summary": "英文文献 RAG 搜索",
-        "description": "**计费**：论文搜索 type 0 = 0.05 元/次；type 1 = 0.1 元/次",
+        "summary": "英文文献搜索",
+        "description": "通过 Bohrium RAG 搜索引擎检索英文学术论文，支持关键词匹配 + 语义理解、时间范围、JCR 分区、数据库筛选。\n\n**计费**：论文搜索 type 0 = 0.05 元/次；type 1 = 0.1 元/次",
         "requestBody": {
           "content": {
             "application/json": {
@@ -4328,19 +5670,44 @@
                   "publicationIds": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "number"
                     }
                   },
                   "subjectIds": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "number"
                     }
                   },
                   "pageSize": {
                     "type": "integer"
                   }
-                }
+                },
+                "required": [
+                  "words",
+                  "question",
+                  "pageSize"
+                ]
+              },
+              "example": {
+                "words": [
+                  "deep learning",
+                  "protein structure"
+                ],
+                "question": "deep learning protein structure prediction",
+                "type": 1,
+                "startTime": "2024-01-01",
+                "endTime": "2025-01-01",
+                "jcrZones": [
+                  "Q1",
+                  "Q2"
+                ],
+                "includeDbs": [
+                  "SCI"
+                ],
+                "areaIds": [],
+                "publicationIds": [],
+                "pageSize": 20
               }
             }
           }
@@ -4368,7 +5735,91 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "doi": {
+                            "type": "string"
+                          },
+                          "paperId": {
+                            "type": "string"
+                          },
+                          "enName": {
+                            "type": "string"
+                          },
+                          "zhName": {
+                            "type": "string"
+                          },
+                          "enAbstract": {
+                            "type": "string"
+                          },
+                          "zhAbstract": {
+                            "type": "string"
+                          },
+                          "authors": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "coverDateStart": {
+                            "type": "string"
+                          },
+                          "publicationEnName": {
+                            "type": "string"
+                          },
+                          "publicationCover": {
+                            "type": "string"
+                          },
+                          "impactFactor": {
+                            "type": "number"
+                          },
+                          "citationNums": {
+                            "type": "integer"
+                          },
+                          "popularity": {
+                            "type": "number"
+                          },
+                          "pieces": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "figures": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "figureId": {
+                                  "type": "string"
+                                },
+                                "imageUrl": {
+                                  "type": "string"
+                                },
+                                "enExplain": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "languageType": {
+                            "type": "integer"
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -4381,8 +5832,8 @@
         "tags": [
           "论文与专利搜索 (bohrium-paper-search)"
         ],
-        "summary": "专利 RAG 搜索",
-        "description": "**计费**：专利搜索 type 0 = 0.1 元/次；type 1 = 0.3 元/次；type 2 = 0.5 元/次",
+        "summary": "专利搜索",
+        "description": "检索全球专利，支持关键词匹配 + 语义理解。patent 搜索的 type 支持 0、1、2。\n\n**计费**：专利搜索 type 0 = 0.1 元/次；type 1 = 0.3 元/次；type 2 = 0.5 元/次",
         "requestBody": {
           "content": {
             "application/json": {
@@ -4404,7 +5855,20 @@
                   "pageSize": {
                     "type": "integer"
                   }
-                }
+                },
+                "required": [
+                  "words",
+                  "question",
+                  "pageSize"
+                ]
+              },
+              "example": {
+                "type": 1,
+                "words": [
+                  "neural network"
+                ],
+                "question": "neural network",
+                "pageSize": 5
               }
             }
           }
@@ -4437,7 +5901,24 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "trace_id": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -4450,8 +5931,8 @@
         "tags": [
           "PDF 解析 (bohrium-pdf-parser)"
         ],
-        "summary": "按 URL 提交解析",
-        "description": "**计费**：0.05 元/页（触发解析时扣，get-result 查询结果免费）",
+        "summary": "URL 提交 PDF 解析",
+        "description": "传入 PDF 下载链接触发解析（Uni-Parser），返回 token 用于查询结果。sync=true 同步等待，sync=false 异步轮询。\n\n**计费**：0.05 元/页（触发解析时扣，get-result 查询结果免费）",
         "requestBody": {
           "content": {
             "application/json": {
@@ -4465,33 +5946,54 @@
                     "type": "boolean"
                   },
                   "textual": {
-                    "type": "boolean"
-                  },
-                  "table": {
-                    "type": "boolean"
-                  },
-                  "chart": {
-                    "type": "boolean"
-                  },
-                  "figure": {
-                    "type": "boolean"
-                  },
-                  "expression": {
-                    "type": "boolean"
+                    "type": "integer"
                   },
                   "equation": {
-                    "type": "boolean"
+                    "type": "integer"
+                  },
+                  "table": {
+                    "type": "integer"
+                  },
+                  "chart": {
+                    "type": "integer"
+                  },
+                  "figure": {
+                    "type": "integer"
+                  },
+                  "expression": {
+                    "type": "integer"
                   },
                   "molecule": {
-                    "type": "boolean"
+                    "type": "integer"
                   },
                   "pages": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    }
                   },
                   "timeout": {
                     "type": "integer"
                   }
-                }
+                },
+                "required": [
+                  "url"
+                ]
+              },
+              "example": {
+                "url": "https://www.nature.com/articles/s41586-021-03819-2.pdf",
+                "sync": false,
+                "textual": 2,
+                "table": 2,
+                "molecule": 0,
+                "chart": 0,
+                "figure": 0,
+                "expression": 1,
+                "equation": 2,
+                "pages": [
+                  0
+                ],
+                "timeout": 1800
               }
             }
           }
@@ -4514,7 +6016,24 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "created_time": {
+                      "type": "string"
+                    },
+                    "page_count": {
+                      "type": "integer"
+                    },
+                    "time_dict": {
+                      "type": "object"
+                    }
+                  }
                 }
               }
             }
@@ -4527,52 +6046,54 @@
         "tags": [
           "PDF 解析 (bohrium-pdf-parser)"
         ],
-        "summary": "按文件上传提交解析（multipart）",
-        "description": "**计费**：0.05 元/页（触发解析时扣，get-result 查询结果免费）",
+        "summary": "文件上传 PDF 解析",
+        "description": "上传本地 PDF 文件触发解析，使用 multipart/form-data。必须由客户端生成并传入 token 字段（网关对 multipart 请求不自动注入 token）。form data 中所有值都是字符串。pages 只能传单个整数。\n\n**计费**：0.05 元/页（触发解析时扣，get-result 查询结果免费）",
         "requestBody": {
           "content": {
-            "application/json": {
+            "multipart/form-data": {
               "schema": {
                 "type": "object",
                 "properties": {
                   "file": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "binary"
                   },
                   "token": {
                     "type": "string"
                   },
                   "sync": {
-                    "type": "boolean"
-                  },
-                  "textual": {
-                    "type": "boolean"
-                  },
-                  "table": {
-                    "type": "boolean"
-                  },
-                  "chart": {
-                    "type": "boolean"
-                  },
-                  "figure": {
-                    "type": "boolean"
-                  },
-                  "expression": {
-                    "type": "boolean"
-                  },
-                  "equation": {
-                    "type": "boolean"
-                  },
-                  "molecule": {
-                    "type": "boolean"
-                  },
-                  "pages": {
                     "type": "string"
                   },
-                  "timeout": {
+                  "textual": {
+                    "type": "string"
+                  },
+                  "table": {
+                    "type": "string"
+                  },
+                  "molecule": {
+                    "type": "string"
+                  },
+                  "chart": {
+                    "type": "string"
+                  },
+                  "figure": {
+                    "type": "string"
+                  },
+                  "expression": {
+                    "type": "string"
+                  },
+                  "equation": {
+                    "type": "string"
+                  },
+                  "pages": {
                     "type": "integer"
+                  },
+                  "timeout": {
+                    "type": "string"
                   }
                 },
                 "required": [
+                  "file",
                   "token"
                 ]
               }
@@ -4597,7 +6118,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -4610,7 +6139,8 @@
         "tags": [
           "PDF 解析 (bohrium-pdf-parser)"
         ],
-        "summary": "轮询/获取解析结果（返回 cost）",
+        "summary": "查询解析结果",
+        "description": "用 token 查询解析结果，status == \"success\" 时完成。查询结果免费。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -4627,11 +6157,958 @@
                     "type": "boolean"
                   },
                   "pages_dict": {
-                    "type": "string"
+                    "type": "boolean"
                   }
                 },
                 "required": [
                   "token"
+                ]
+              },
+              "example": {
+                "token": "YOUR_TOKEN",
+                "content": true,
+                "objects": false,
+                "pages_dict": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "token": {
+                      "type": "string"
+                    },
+                    "content": {
+                      "type": "string"
+                    },
+                    "pages_dict": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "lang": {
+                      "type": "string"
+                    },
+                    "proc_page": {
+                      "type": "integer"
+                    },
+                    "total_page": {
+                      "type": "integer"
+                    },
+                    "proc_textual": {
+                      "type": "integer"
+                    },
+                    "total_textual": {
+                      "type": "integer"
+                    },
+                    "proc_table": {
+                      "type": "integer"
+                    },
+                    "total_table": {
+                      "type": "integer"
+                    },
+                    "proc_mol": {
+                      "type": "integer"
+                    },
+                    "total_mol": {
+                      "type": "integer"
+                    },
+                    "proc_equa": {
+                      "type": "integer"
+                    },
+                    "total_equa": {
+                      "type": "integer"
+                    },
+                    "time_dict": {
+                      "type": "object"
+                    },
+                    "cost": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v2/sigma-search/api/v4/ai_search/sessions": {
+      "post": {
+        "tags": [
+          "AI 科学小导师 (bohrium-mentor)"
+        ],
+        "summary": "创建 AI 搜索会话",
+        "description": "提交科学问题，调用 adk_science_navigator Agent，返回 sessionId 用于订阅 SSE 流。\n\n**计费**：2 元/次 或 200 光子/次（创建会话时收取）",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "discipline": {
+                    "type": "string"
+                  },
+                  "scene": {
+                    "type": "string"
+                  },
+                  "journal_type": {
+                    "type": "string"
+                  },
+                  "snp_version": {
+                    "type": "string"
+                  },
+                  "resource_id_list": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "SNPReq": {
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "query"
+                ]
+              },
+              "example": {
+                "query": "CRISPR-Cas9 近三年在基因治疗领域的最新进展",
+                "model": "reason",
+                "discipline": "All",
+                "scene": "adk_science_navigator",
+                "journal_type": "foreign",
+                "snp_version": "1.0.0",
+                "resource_id_list": [],
+                "SNPReq": {
+                  "sessionId": "",
+                  "channel": {
+                    "schema": "fe",
+                    "version": "v1",
+                    "role": "user",
+                    "auth": 1,
+                    "messageId": "<uuid>",
+                    "answerId": "<uuid>",
+                    "uiInfo": {
+                      "layout": "main",
+                      "type": "ui",
+                      "subType": "@bohrium-chat/common/markdown",
+                      "content": {
+                        "text": "CRISPR-Cas9 近三年在基因治疗领域的最新进展"
+                      },
+                      "actionList": [
+                        {
+                          "key": "text",
+                          "action": "append"
+                        }
+                      ]
+                    },
+                    "entities": [],
+                    "state": {},
+                    "meta": {}
+                  },
+                  "system": {
+                    "payload": {
+                      "model": "reason",
+                      "agentId": "science_navigator",
+                      "sessionId": "",
+                      "scene": "adk_science_navigator",
+                      "streaming": true,
+                      "biz": {
+                        "uploadList": [],
+                        "sn": {
+                          "discipline": "All",
+                          "journal_type": "foreign",
+                          "model": "reason"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-bohrium-price": {
+          "billable": true,
+          "currency": "CNY",
+          "skill": "bohrium-mentor",
+          "items": [
+            {
+              "amount": 2,
+              "unit": "次"
+            }
+          ],
+          "note": "2 元/次 或 200 光子/次"
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "sessionId": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v2/sigma-search/api/v3/sse/ai_search/v1/{sessionId}/stream": {
+      "get": {
+        "tags": [
+          "AI 科学小导师 (bohrium-mentor)"
+        ],
+        "summary": "订阅 SSE 推理流",
+        "description": "订阅 SSE 流，实时接收基于 SNP2 协议的思考链与正文流事件（append/delta/patch）。",
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SSE 事件流。每个事件格式为 `event:data` + `data:{\"channel\":{...},\"system\":{...},\"sessionId\":\"...\"}`，通过 append/delta/patch 增量构建思考链、正文、资源与侧边栏。",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v2/sigma-search/api/v4/ai_search/sessions/{sessionId}": {
+      "get": {
+        "tags": [
+          "AI 科学小导师 (bohrium-mentor)"
+        ],
+        "summary": "查询会话元数据",
+        "description": "查询会话状态/标题等元信息（仅返回元数据，不返回完整消息历史）。",
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v2/sigma-search/api/v4/{sessionId}/history": {
+      "get": {
+        "tags": [
+          "AI 科学小导师 (bohrium-mentor)"
+        ],
+        "summary": "查询会话历史",
+        "description": "断线恢复/历史回显，返回聚合后的完整结果。返回 historyData 数组，每条记录对应一个完整的消息事件（用户提问、思考过程、资源元数据、正文答案、侧边栏、操作按钮、推荐问题）。",
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "historyData": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v1/lkm/search": {
+      "post": {
+        "tags": [
+          "大知识模型 (bohrium-lkm)"
+        ],
+        "summary": "公开检索",
+        "description": "用自然语言召回 LKM 中的 claim / question / abstract 命中。默认按论文聚合。\n\n**计费**：按调用计费，实际费用以账单为准",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string"
+                  },
+                  "keywords": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "retrieval_mode": {
+                    "type": "string"
+                  },
+                  "sort_by": {
+                    "type": "string"
+                  },
+                  "scopes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "filters": {
+                    "type": "object",
+                    "properties": {
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "role": {
+                        "type": "string"
+                      },
+                      "paper_ids": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "dois": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "publication_date_start": {
+                        "type": "string"
+                      },
+                      "publication_date_end": {
+                        "type": "string"
+                      },
+                      "limit_publication_date": {
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "reasoning_only": {
+                    "type": "boolean"
+                  },
+                  "include_paper_enrich": {
+                    "type": "boolean"
+                  },
+                  "offset": {
+                    "type": "integer"
+                  },
+                  "limit": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "query"
+                ]
+              },
+              "example": {
+                "query": "The 2017 chemistry curriculum standard increases emphasis on real-world problem situations and contexts.",
+                "keywords": [
+                  "real-world contexts",
+                  "industrial production",
+                  "inquiry learning"
+                ],
+                "retrieval_mode": "hybrid",
+                "sort_by": "comprehensive",
+                "scopes": [
+                  "claim",
+                  "question",
+                  "abstract",
+                  "conclusion",
+                  "premise"
+                ],
+                "reasoning_only": false,
+                "offset": 0,
+                "limit": 20
+              }
+            }
+          }
+        },
+        "x-bohrium-price": {
+          "billable": true,
+          "currency": "CNY",
+          "skill": "bohrium-lkm",
+          "note": "按调用计费，实际费用以账单为准"
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "variables": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "score": {
+                                "type": "number"
+                              },
+                              "rerank_score": {
+                                "type": "number"
+                              },
+                              "has_reasoning": {
+                                "type": "boolean"
+                              },
+                              "content": {
+                                "type": "string"
+                              },
+                              "provenance": {
+                                "type": "object",
+                                "properties": {
+                                  "source_packages": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "related": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "papers": {
+                          "type": "object"
+                        },
+                        "has_more": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v1/lkm/reasoning/search": {
+      "post": {
+        "tags": [
+          "大知识模型 (bohrium-lkm)"
+        ],
+        "summary": "推理链检索",
+        "description": "按论证过程相似性召回整条推理链。新调用方统一传 format: \"graph\"。",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string"
+                  },
+                  "keywords": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "retrieval_mode": {
+                    "type": "string"
+                  },
+                  "sort_by": {
+                    "type": "string"
+                  },
+                  "format": {
+                    "type": "string"
+                  },
+                  "filters": {
+                    "type": "object",
+                    "properties": {
+                      "paper_ids": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "dois": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "publication_date_start": {
+                        "type": "string"
+                      },
+                      "publication_date_end": {
+                        "type": "string"
+                      },
+                      "limit_publication_date": {
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "offset": {
+                    "type": "integer"
+                  },
+                  "limit": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "query"
+                ]
+              },
+              "example": {
+                "query": "infer phase stability from XRD evidence",
+                "keywords": [
+                  "powder XRD",
+                  "Rietveld refinement",
+                  "phase transition"
+                ],
+                "retrieval_mode": "hybrid",
+                "sort_by": "comprehensive",
+                "format": "graph",
+                "offset": 0,
+                "limit": 20
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "reasoning_chains": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "chain_id": {
+                                "type": "string"
+                              },
+                              "paper_id": {
+                                "type": "string"
+                              },
+                              "score": {
+                                "type": "number"
+                              },
+                              "graph": {
+                                "type": "object",
+                                "properties": {
+                                  "nodes": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object"
+                                    }
+                                  },
+                                  "edges": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object"
+                                    }
+                                  }
+                                }
+                              },
+                              "paper": {
+                                "type": "object"
+                              },
+                              "addressed_problems": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              },
+                              "open_questions": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "total": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v1/lkm/papers/graph": {
+      "post": {
+        "tags": [
+          "大知识模型 (bohrium-lkm)"
+        ],
+        "summary": "论文级知识图谱",
+        "description": "给定一篇论文，返回 LKM 从中抽取出的完整 graph。4 个标识（package_id/paper_id/doi/title）至少传 1 个。优先级：package_id > paper_id > doi > title。",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "package_id": {
+                    "type": "string"
+                  },
+                  "paper_id": {
+                    "type": "string"
+                  },
+                  "doi": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "title_resolve": {
+                    "type": "object",
+                    "properties": {
+                      "limit": {
+                        "type": "integer"
+                      }
+                    }
+                  }
+                }
+              },
+              "example": {
+                "package_id": "paper:1020661015349559308"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "papers": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "paper": {
+                                "type": "object"
+                              },
+                              "graph": {
+                                "type": "object",
+                                "properties": {
+                                  "nodes": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object"
+                                    }
+                                  },
+                                  "edges": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object"
+                                    }
+                                  }
+                                }
+                              },
+                              "addressed_problems": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              },
+                              "open_questions": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v1/lkm/claims/{id}/reasoning": {
+      "get": {
+        "tags": [
+          "大知识模型 (bohrium-lkm)"
+        ],
+        "summary": "单条命题推理链",
+        "description": "给定一个全局 claim ID（gcn_...），返回这条 claim 由哪些推理步骤和前提支撑。新调用方统一传 format=graph。建议只对 role=conclusion 且 has_reasoning=true 的 claim 调用。",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "max_chains",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "claim": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "content_hash": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "reasoning_chains": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "graph": {
+                                "type": "object",
+                                "properties": {
+                                  "nodes": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object"
+                                    }
+                                  },
+                                  "edges": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object"
+                                    }
+                                  }
+                                }
+                              },
+                              "paper": {
+                                "type": "object"
+                              },
+                              "addressed_problems": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              },
+                              "open_questions": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "total_chains": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v1/lkm/variables/batch": {
+      "post": {
+        "tags": [
+          "大知识模型 (bohrium-lkm)"
+        ],
+        "summary": "批量水合节点详情",
+        "description": "按节点 ID 列表批量取详情。这不是检索接口。请求前先清洗：去空串、去 null、去重、单批 ≤100。",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "ids"
+                ]
+              },
+              "example": {
+                "ids": [
+                  "gcn_654cd35dcb814a0c",
+                  "gcn_9523aa7f1fd04d8a"
                 ]
               }
             }
@@ -4643,7 +7120,67 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "variables": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "title": {
+                                "type": "string"
+                              },
+                              "content": {
+                                "type": "string"
+                              },
+                              "representative_lcn": {
+                                "type": "string"
+                              },
+                              "local_members": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              },
+                              "provenance": {
+                                "type": "object"
+                              },
+                              "metadata": {
+                                "type": "string"
+                              },
+                              "parameters": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "not_found": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "papers": {
+                          "type": "object"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -4651,65 +7188,41 @@
         }
       }
     },
-    "/openapi/v2/project/list": {
-      "get": {
-        "tags": [
-          "项目管理 (bohrium-project)"
-        ],
-        "summary": "详细项目列表",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/project/lite_list": {
-      "get": {
-        "tags": [
-          "项目管理 (bohrium-project)"
-        ],
-        "summary": "精简列表（id+name）",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/project/set_name": {
+    "/openapi/v1/lkm/feedback": {
       "post": {
         "tags": [
-          "项目管理 (bohrium-project)"
+          "大知识模型 (bohrium-lkm)"
         ],
-        "summary": "重命名项目",
+        "summary": "提交反馈",
+        "description": "对 LKM 服务/数据提交反馈。可选地关联到一个 GCN 节点或一篇论文元数据（gcn_id 与 paper_metadata_id 互斥）。这是写入接口，不返回知识内容。",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
                 "properties": {
-                  "projectId": {
+                  "type": {
                     "type": "string"
                   },
-                  "name": {
+                  "content": {
+                    "type": "string"
+                  },
+                  "gcn_id": {
+                    "type": "string"
+                  },
+                  "paper_metadata_id": {
                     "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "type",
+                  "content"
+                ]
+              },
+              "example": {
+                "type": "bug",
+                "content": "推理链查询返回结果中缺少前提节点，疑似数据缺失",
+                "gcn_id": "gcn_0002bee76d0c4255"
               }
             }
           }
@@ -4720,696 +7233,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/project/set_cost_limit": {
-      "post": {
-        "tags": [
-          "项目管理 (bohrium-project)"
-        ],
-        "summary": "设置成本上限",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "projectId": {
-                    "type": "string"
-                  },
-                  "costLimit": {
-                    "type": "integer"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        }
+                      }
+                    }
                   }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/project/{id}/users": {
-      "get": {
-        "tags": [
-          "项目管理 (bohrium-project)"
-        ],
-        "summary": "项目成员",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/project/add_user": {
-      "post": {
-        "tags": [
-          "项目管理 (bohrium-project)"
-        ],
-        "summary": "添加成员",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "projectId": {
-                    "type": "string"
-                  },
-                  "email": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/project/del_user": {
-      "post": {
-        "tags": [
-          "项目管理 (bohrium-project)"
-        ],
-        "summary": "移除成员",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "projectId": {
-                    "type": "string"
-                  },
-                  "userId": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/project/manager/add": {
-      "post": {
-        "tags": [
-          "项目管理 (bohrium-project)"
-        ],
-        "summary": "添加管理员",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "projectId": {
-                    "type": "string"
-                  },
-                  "userId": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/project/manager/del": {
-      "post": {
-        "tags": [
-          "项目管理 (bohrium-project)"
-        ],
-        "summary": "移除管理员",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "projectId": {
-                    "type": "string"
-                  },
-                  "userId": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/project/{id}/recovery_user": {
-      "put": {
-        "tags": [
-          "项目管理 (bohrium-project)"
-        ],
-        "summary": "恢复被移除成员",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "userId": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/image/public/version/search": {
-      "get": {
-        "tags": [
-          "容器镜像 (bohrium-image)"
-        ],
-        "summary": "搜索公开镜像版本",
-        "parameters": [
-          {
-            "name": "keyword",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/image/public": {
-      "get": {
-        "tags": [
-          "容器镜像 (bohrium-image)"
-        ],
-        "summary": "公开镜像分类",
-        "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/image/public/{image_id}/version": {
-      "get": {
-        "tags": [
-          "容器镜像 (bohrium-image)"
-        ],
-        "summary": "公开镜像版本",
-        "parameters": [
-          {
-            "name": "image_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/image/private": {
-      "post": {
-        "tags": [
-          "容器镜像 (bohrium-image)"
-        ],
-        "summary": "创建私有镜像（Dockerfile 构建）",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "projectId": {
-                    "type": "string"
-                  },
-                  "device": {
-                    "type": "string"
-                  },
-                  "buildType": {
-                    "type": "string"
-                  },
-                  "dockerfile": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "tags": [
-          "容器镜像 (bohrium-image)"
-        ],
-        "summary": "私有镜像列表",
-        "parameters": [
-          {
-            "name": "device",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "type",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/image/private/{image_id}": {
-      "get": {
-        "tags": [
-          "容器镜像 (bohrium-image)"
-        ],
-        "summary": "私有镜像详情",
-        "parameters": [
-          {
-            "name": "image_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "容器镜像 (bohrium-image)"
-        ],
-        "summary": "更新镜像描述",
-        "parameters": [
-          {
-            "name": "image_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "desc": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/image/dockerfile/check": {
-      "post": {
-        "tags": [
-          "容器镜像 (bohrium-image)"
-        ],
-        "summary": "校验 Dockerfile",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "dockerfile": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/image/last_used": {
-      "get": {
-        "tags": [
-          "容器镜像 (bohrium-image)"
-        ],
-        "summary": "最近使用镜像",
-        "parameters": [
-          {
-            "name": "type",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/image/{image_id}/share": {
-      "post": {
-        "tags": [
-          "容器镜像 (bohrium-image)"
-        ],
-        "summary": "分享镜像",
-        "parameters": [
-          {
-            "name": "image_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "容器镜像 (bohrium-image)"
-        ],
-        "summary": "取消分享",
-        "parameters": [
-          {
-            "name": "image_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "device",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
                 }
               }
             }
@@ -5422,7 +7262,8 @@
         "tags": [
           "学者搜索 (bohrium-scholar-search)"
         ],
-        "summary": "搜索学者",
+        "summary": "学者搜索",
+        "description": "按姓名/机构/研究方向等条件检索学者候选列表。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5454,6 +7295,11 @@
                 "required": [
                   "name"
                 ]
+              },
+              "example": {
+                "name": "Yann LeCun",
+                "page": 1,
+                "pageSize": 5
               }
             }
           }
@@ -5464,7 +7310,49 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "scholarId": {
+                                "type": "string"
+                              },
+                              "nameEn": {
+                                "type": "string"
+                              },
+                              "nameZh": {
+                                "type": "string"
+                              },
+                              "paperNums": {
+                                "type": "integer"
+                              },
+                              "citationNums": {
+                                "type": "integer"
+                              },
+                              "hIndex": {
+                                "type": "integer"
+                              },
+                              "scholarOrgNameEn": {
+                                "type": "string"
+                              },
+                              "scholarOrgNameZh": {
+                                "type": "string"
+                              },
+                              "isHighCited": {
+                                "type": "boolean"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -5477,7 +7365,8 @@
         "tags": [
           "学者搜索 (bohrium-scholar-search)"
         ],
-        "summary": "学者完整画像",
+        "summary": "学者详情",
+        "description": "根据 scholarId 获取完整画像（发文量、引用、h-index、研究方向、教育/工作经历）。",
         "parameters": [
           {
             "name": "scholarId",
@@ -5494,7 +7383,120 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "scholarId": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "type": "string"
+                        },
+                        "nameZh": {
+                          "type": "string"
+                        },
+                        "paperNums": {
+                          "type": "integer"
+                        },
+                        "citationNums": {
+                          "type": "integer"
+                        },
+                        "hIndex": {
+                          "type": "integer"
+                        },
+                        "scholarOrgNameEn": {
+                          "type": "string"
+                        },
+                        "scholarOrgNameZh": {
+                          "type": "string"
+                        },
+                        "isHighCited": {
+                          "type": "boolean"
+                        },
+                        "researchDirection": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "educationBackground": {
+                          "type": "string"
+                        },
+                        "educationBackgroundZh": {
+                          "type": "string"
+                        },
+                        "workExperience": {
+                          "type": "string"
+                        },
+                        "workExperienceZh": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v2/search/web": {
+      "get": {
+        "tags": [
+          "网页搜索 (bohrium-web-search)"
+        ],
+        "summary": "网页搜索",
+        "description": "代理到 searchapi.io，对开放互联网做关键词搜索，返回标题、链接、摘要的结果列表。",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "num",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "organic_results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string"
+                          },
+                          "link": {
+                            "type": "string"
+                          },
+                          "snippet": {
+                            "type": "string"
+                          },
+                          "position": {
+                            "type": "integer"
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -5507,7 +7509,8 @@
         "tags": [
           "科学百科 (bohrium-sciencepedia)"
         ],
-        "summary": "统一搜索（词条+关键词+领域）",
+        "summary": "统一搜索",
+        "description": "一次返回相关的词条 + 关键词（articles）和相关课程（fields），每条带高亮简介。language: en-US 或 zh-CN；style: Feynman 或 Hardcore。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5523,7 +7526,15 @@
                   "style": {
                     "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "text"
+                ]
+              },
+              "example": {
+                "text": "graphene",
+                "language": "en-US",
+                "style": "Feynman"
               }
             }
           }
@@ -5534,7 +7545,62 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "articles": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string"
+                              },
+                              "id": {
+                                "type": "string"
+                              },
+                              "article_name": {
+                                "type": "string"
+                              },
+                              "matched_elements": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "content": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "fields": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "node_id": {
+                                "type": "string"
+                              },
+                              "field_id": {
+                                "type": "string"
+                              },
+                              "node_name": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -5547,7 +7613,8 @@
         "tags": [
           "科学百科 (bohrium-sciencepedia)"
         ],
-        "summary": "词条文章全文",
+        "summary": "词条全文",
+        "description": "按 entry_id 取主题文章正文。偶尔返回 code=250002（内容尚未生成），此时回退用搜索片段或换 style/language。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5563,7 +7630,15 @@
                   "style": {
                     "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "entry_id"
+                ]
+              },
+              "example": {
+                "entry_id": "<entry_id>",
+                "language": "en-US",
+                "style": "Feynman"
               }
             }
           }
@@ -5574,7 +7649,40 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "document": {
+                          "type": "object",
+                          "properties": {
+                            "article_name": {
+                              "type": "string"
+                            },
+                            "seo_description": {
+                              "type": "string"
+                            },
+                            "definition": {
+                              "type": "string"
+                            },
+                            "key_points": {
+                              "type": "string"
+                            },
+                            "main_content": {
+                              "type": "string"
+                            },
+                            "applications": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -5588,6 +7696,7 @@
           "科学百科 (bohrium-sciencepedia)"
         ],
         "summary": "关键词全文",
+        "description": "按 keyword_id 取关键词内容。偶尔返回 code=250002（内容尚未生成），此时回退用搜索片段或换 style/language。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5603,7 +7712,15 @@
                   "style": {
                     "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "keyword_id"
+                ]
+              },
+              "example": {
+                "keyword_id": "<keyword_id>",
+                "language": "en-US",
+                "style": "Feynman"
               }
             }
           }
@@ -5614,7 +7731,40 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "document": {
+                          "type": "object",
+                          "properties": {
+                            "article_name": {
+                              "type": "string"
+                            },
+                            "seo_description": {
+                              "type": "string"
+                            },
+                            "definition": {
+                              "type": "string"
+                            },
+                            "key_points": {
+                              "type": "string"
+                            },
+                            "main_content": {
+                              "type": "string"
+                            },
+                            "applications": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -5627,7 +7777,8 @@
         "tags": [
           "科学百科 (bohrium-sciencepedia)"
         ],
-        "summary": "学科与层级",
+        "summary": "学科结构",
+        "description": "返回所有大类(major)及其分级(level)。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5641,6 +7792,10 @@
                     "type": "string"
                   }
                 }
+              },
+              "example": {
+                "language": "en-US",
+                "style": "Feynman"
               }
             }
           }
@@ -5651,7 +7806,42 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "majors": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "levels": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "node_id": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -5664,7 +7854,8 @@
         "tags": [
           "科学百科 (bohrium-sciencepedia)"
         ],
-        "summary": "层级下课程（分页）",
+        "summary": "课程列表",
+        "description": "列出某些分级下的课程(field)，分页返回。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5682,8 +7873,23 @@
                   },
                   "page_size": {
                     "type": "integer"
+                  },
+                  "language": {
+                    "type": "string"
+                  },
+                  "style": {
+                    "type": "string"
                   }
                 }
+              },
+              "example": {
+                "node_ids": [
+                  "<level_node_id>"
+                ],
+                "page_num": 1,
+                "page_size": 20,
+                "language": "en-US",
+                "style": "Feynman"
               }
             }
           }
@@ -5694,7 +7900,70 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "total": {
+                          "type": "integer"
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "major": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "level": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "field": {
+                                "type": "object",
+                                "properties": {
+                                  "node_id": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "seo_title": {
+                                    "type": "string"
+                                  },
+                                  "field_id": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "topic_count": {
+                                "type": "integer"
+                              },
+                              "topics": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -5707,7 +7976,8 @@
         "tags": [
           "科学百科 (bohrium-sciencepedia)"
         ],
-        "summary": "课程章节树+词条",
+        "summary": "课程结构",
+        "description": "取课程的章节树 + 知识点。树是 4 层：field → category → chapter → entry。叶子 entry 节点带 entry_id。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5717,10 +7987,21 @@
                   "field_id": {
                     "type": "string"
                   },
-                  "node_id": {
+                  "language": {
+                    "type": "string"
+                  },
+                  "style": {
                     "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "field_id"
+                ]
+              },
+              "example": {
+                "field_id": "<field_id>",
+                "language": "en-US",
+                "style": "Feynman"
               }
             }
           }
@@ -5731,7 +8012,61 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "wiki_indices": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "node_id": {
+                                "type": "string"
+                              },
+                              "node_type": {
+                                "type": "string"
+                              },
+                              "node_name": {
+                                "type": "string"
+                              },
+                              "entry_id": {
+                                "type": "string"
+                              },
+                              "snapshot": {
+                                "type": "string"
+                              },
+                              "seo_title": {
+                                "type": "string"
+                              },
+                              "children": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "entry_count": {
+                          "type": "integer"
+                        },
+                        "foundational_entry_count": {
+                          "type": "integer"
+                        },
+                        "core_entry_count": {
+                          "type": "integer"
+                        },
+                        "advanced_entry_count": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -5744,12 +8079,13 @@
         "tags": [
           "科学百科 (bohrium-sciencepedia)"
         ],
-        "summary": "主题知识图谱",
+        "summary": "知识图谱",
+        "description": "从一个中心节点（词条或关键词）向外扩展，得到它和相关概念组成的图。",
         "parameters": [
           {
             "name": "id",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -5785,7 +8121,95 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "nodes": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "node_id": {
+                                "type": "string"
+                              },
+                              "node_type": {
+                                "type": "string"
+                              },
+                              "display_name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "field_name": {
+                                "type": "string"
+                              },
+                              "major_name": {
+                                "type": "string"
+                              },
+                              "depth": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        },
+                        "relationships": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "src_node_id": {
+                                "type": "string"
+                              },
+                              "desc_node_id": {
+                                "type": "string"
+                              },
+                              "relationship": {
+                                "type": "string"
+                              },
+                              "relation_type": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "weight": {
+                                "type": "number"
+                              },
+                              "evidence_count": {
+                                "type": "integer"
+                              },
+                              "is_bidirectional": {
+                                "type": "boolean"
+                              },
+                              "is_cross_domain": {
+                                "type": "boolean"
+                              }
+                            }
+                          }
+                        },
+                        "domains": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "major_node_id": {
+                                "type": "string"
+                              },
+                              "major_name": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -5798,10 +8222,19 @@
         "tags": [
           "科学百科 (bohrium-sciencepedia)"
         ],
-        "summary": "单节点详情",
+        "summary": "图谱节点详情",
+        "description": "获取单个节点详情。",
         "parameters": [
           {
             "name": "id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "node_type",
             "in": "query",
             "required": false,
             "schema": {
@@ -5809,7 +8242,15 @@
             }
           },
           {
-            "name": "node_type",
+            "name": "language",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "style",
             "in": "query",
             "required": false,
             "schema": {
@@ -5823,7 +8264,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object"
+                    }
+                  }
                 }
               }
             }
@@ -5836,12 +8285,13 @@
         "tags": [
           "科学百科 (bohrium-sciencepedia)"
         ],
-        "summary": "单关系详情",
+        "summary": "图谱关系详情",
+        "description": "获取单条关系详情（含支撑证据 evidences）。",
         "parameters": [
           {
             "name": "src_node_id",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -5849,7 +8299,7 @@
           {
             "name": "desc_node_id",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -5857,9 +8307,25 @@
           {
             "name": "relation_id",
             "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "language",
+            "in": "query",
             "required": false,
             "schema": {
-              "type": "integer"
+              "type": "string"
+            }
+          },
+          {
+            "name": "style",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -5869,7 +8335,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object"
+                    }
+                  }
                 }
               }
             }
@@ -5882,7 +8356,8 @@
         "tags": [
           "科学百科 (bohrium-sciencepedia)"
         ],
-        "summary": "图内查找节点",
+        "summary": "图谱内检索",
+        "description": "在图谱里按词找节点。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5892,7 +8367,13 @@
                   "text": {
                     "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "text"
+                ]
+              },
+              "example": {
+                "text": "entropy"
               }
             }
           }
@@ -5903,7 +8384,28 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -5916,14 +8418,23 @@
         "tags": [
           "科学百科 (bohrium-sciencepedia)"
         ],
-        "summary": "词条/关键词统计",
+        "summary": "基础信息",
+        "description": "词条 / 关键词总量。",
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object"
+                    }
+                  }
                 }
               }
             }
@@ -5936,20 +8447,13 @@
         "tags": [
           "科学百科 (bohrium-sciencepedia)"
         ],
-        "summary": "按名称搜索节点",
+        "summary": "名称搜索",
+        "description": "按名字搜节点（如只要 field），可放开 node_types。",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "node_types": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                }
+                "type": "object"
               }
             }
           }
@@ -5960,7 +8464,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object"
+                    }
+                  }
                 }
               }
             }
@@ -5973,14 +8485,45 @@
         "tags": [
           "科学工具库 (bohrium-tools)"
         ],
-        "summary": "工具领域列表",
+        "summary": "列出领域",
+        "description": "列出所有工具领域。展示语言由 HTTP 头 Content-Language(en-us/zh-cn) 决定。",
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "trace_id": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "node_id": {
+                                "type": "string"
+                              },
+                              "node_name": {
+                                "type": "string"
+                              },
+                              "tool_num": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -5993,14 +8536,28 @@
         "tags": [
           "科学工具库 (bohrium-tools)"
         ],
-        "summary": "工具总数",
+        "summary": "工具总数统计",
+        "description": "返回工具总数。",
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "total_num": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -6013,7 +8570,8 @@
         "tags": [
           "科学工具库 (bohrium-tools)"
         ],
-        "summary": "子领域列表（分页）",
+        "summary": "列出子领域",
+        "description": "列出领域下的子领域，分页返回。domain_node_ids 可为空表示全部。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -6033,6 +8591,13 @@
                     "type": "integer"
                   }
                 }
+              },
+              "example": {
+                "domain_node_ids": [
+                  "DOMAIN_NODE_ID"
+                ],
+                "page": 1,
+                "page_size": 20
               }
             }
           }
@@ -6043,7 +8608,66 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "total": {
+                          "type": "integer"
+                        },
+                        "page": {
+                          "type": "integer"
+                        },
+                        "pageSize": {
+                          "type": "integer"
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "node_id": {
+                                "type": "string"
+                              },
+                              "node_name": {
+                                "type": "string"
+                              },
+                              "tool_num": {
+                                "type": "integer"
+                              },
+                              "tags": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              },
+                              "tools": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "tool_unique_key": {
+                                      "type": "string"
+                                    },
+                                    "tool_name": {
+                                      "type": "string"
+                                    },
+                                    "avatar_url": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -6057,6 +8681,7 @@
           "科学工具库 (bohrium-tools)"
         ],
         "summary": "子领域详情",
+        "description": "获取子领域详情。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -6066,7 +8691,13 @@
                   "subdomain_node_id": {
                     "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "subdomain_node_id"
+                ]
+              },
+              "example": {
+                "subdomain_node_id": "SUBDOMAIN_NODE_ID"
               }
             }
           }
@@ -6077,7 +8708,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "node_id": {
+                          "type": "string"
+                        },
+                        "node_name": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -6090,7 +8737,8 @@
         "tags": [
           "科学工具库 (bohrium-tools)"
         ],
-        "summary": "子领域下工具",
+        "summary": "子领域下的工具列表",
+        "description": "列出子领域下的工具，支持标签筛选、排序、分页。sort_by 合法值：popular / latest / similarity；未知值回退 popular。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -6118,7 +8766,18 @@
                   "page_size": {
                     "type": "integer"
                   }
-                }
+                },
+                "required": [
+                  "subdomain_node_id"
+                ]
+              },
+              "example": {
+                "subdomain_node_id": "SUBDOMAIN_NODE_ID",
+                "tag_ids": [],
+                "sort_by": "popular",
+                "sort_type": "desc",
+                "page": 1,
+                "page_size": 10
               }
             }
           }
@@ -6129,7 +8788,58 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "total": {
+                          "type": "integer"
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "profile": {
+                                "type": "string"
+                              },
+                              "tags": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              },
+                              "star_count": {
+                                "type": "integer"
+                              },
+                              "related_entry_count": {
+                                "type": "integer"
+                              },
+                              "last_commit_time": {
+                                "type": "string"
+                              },
+                              "avatar_url": {
+                                "type": "string"
+                              },
+                              "tool_unique_key": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -6143,11 +8853,12 @@
           "科学工具库 (bohrium-tools)"
         ],
         "summary": "工具详情",
+        "description": "按 tool_unique_key 获取工具完整档案（GitHub 指标、教程、关联词条、Docker 镜像、MCP 地址等）。",
         "parameters": [
           {
             "name": "tool_unique_key",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -6159,7 +8870,83 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "profile": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "string"
+                        },
+                        "star_count": {
+                          "type": "integer"
+                        },
+                        "fork_count": {
+                          "type": "integer"
+                        },
+                        "watch_count": {
+                          "type": "integer"
+                        },
+                        "key_points": {
+                          "type": "string"
+                        },
+                        "overview": {
+                          "type": "string"
+                        },
+                        "tutorial": {
+                          "type": "string"
+                        },
+                        "related_entry_list": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "primary_language": {
+                          "type": "string"
+                        },
+                        "license": {
+                          "type": "string"
+                        },
+                        "mcp_url": {
+                          "type": "string"
+                        },
+                        "docker_image_uri": {
+                          "type": "string"
+                        },
+                        "repo_url": {
+                          "type": "string"
+                        },
+                        "help_urls": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "sub_domains": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "tags": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -6173,6 +8960,7 @@
           "科学工具库 (bohrium-tools)"
         ],
         "summary": "子领域标签",
+        "description": "获取一组子领域下的标签。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -6185,7 +8973,16 @@
                       "type": "string"
                     }
                   }
-                }
+                },
+                "required": [
+                  "subdomain_node_ids"
+                ]
+              },
+              "example": {
+                "subdomain_node_ids": [
+                  "SUBDOMAIN_NODE_ID1",
+                  "SUBDOMAIN_NODE_ID2"
+                ]
               }
             }
           }
@@ -6196,7 +8993,31 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "tag_name": {
+                                "type": "string"
+                              },
+                              "tag_id": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -6209,7 +9030,8 @@
         "tags": [
           "科学工具库 (bohrium-tools)"
         ],
-        "summary": "混合工具检索",
+        "summary": "工具混合检索",
+        "description": "用自然语言 text + 关键词权重 keywords 做 BM25 + 向量的混合召回。text 与 keywords 均为必填；language 必须与 Content-Language 头二选一。k 上限 500。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -6220,10 +9042,7 @@
                     "type": "string"
                   },
                   "keywords": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
+                    "type": "object"
                   },
                   "language": {
                     "type": "string"
@@ -6234,7 +9053,21 @@
                   "return_level": {
                     "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "text",
+                  "keywords"
+                ]
+              },
+              "example": {
+                "text": "molecular dynamics simulation engine with GPU support",
+                "keywords": {
+                  "molecular dynamics": 1.0,
+                  "GPU": 0.6
+                },
+                "language": "en-US",
+                "k": 50,
+                "return_level": ""
               }
             }
           }
@@ -6245,7 +9078,70 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "total": {
+                          "type": "integer"
+                        },
+                        "tools": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "tool_id": {
+                                "type": "string"
+                              },
+                              "tool_name": {
+                                "type": "string"
+                              },
+                              "tool_unique_key": {
+                                "type": "string"
+                              },
+                              "domains": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              },
+                              "subdomains": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              },
+                              "tags": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              },
+                              "profile": {
+                                "type": "string"
+                              },
+                              "repo_url": {
+                                "type": "string"
+                              },
+                              "score": {
+                                "type": "number"
+                              },
+                              "matched_chunks": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -6258,7 +9154,8 @@
         "tags": [
           "科学工具库 (bohrium-tools)"
         ],
-        "summary": "子领域搜索",
+        "summary": "子领域检索",
+        "description": "把模糊主题映射到子领域 node_id。language 必须与 Content-Language 头二选一。",
         "requestBody": {
           "content": {
             "application/json": {
@@ -6271,7 +9168,14 @@
                   "language": {
                     "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "text"
+                ]
+              },
+              "example": {
+                "text": "protein structure prediction",
+                "language": "en-US"
               }
             }
           }
@@ -6282,45 +9186,31 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/openapi/v2/search/web": {
-      "get": {
-        "tags": [
-          "网页搜索 (bohrium-web-search)"
-        ],
-        "summary": "开放网页搜索",
-        "parameters": [
-          {
-            "name": "q",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "num",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "subdomains": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "node_display_name": {
+                                "type": "string"
+                              },
+                              "node_id": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -6335,23 +9225,6 @@
         "type": "http",
         "scheme": "bearer",
         "description": "Bohrium AccessKey，环境变量 BOHR_ACCESS_KEY，作为 Bearer token"
-      }
-    },
-    "schemas": {
-      "ApiResponse": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "integer",
-            "description": "0 成功，2000 未授权"
-          },
-          "message": {
-            "type": "string"
-          },
-          "data": {
-            "type": "object"
-          }
-        }
       }
     }
   },

--- a/docs/api/owners.yaml
+++ b/docs/api/owners.yaml
@@ -1,0 +1,159 @@
+# Bohrium OpenAPI — 模块认责注册表 (module ownership registry)
+#
+# 用途：把「日志里的接口路径」映射到「负责的团队/人」，用于快速追溯与派单。
+# 查询：python3 tools/whoowns.py "<路径或日志行>"
+#
+# path_prefixes 已按模块填好（powers whoowns，勿随意改）；
+# team/owner/contact/service_repo/oncall 由各模块负责团队自行填写并在 PR 中维护。
+# 空字段表示尚未认领 —— 认领即把自己填进去，责任随之明确。
+
+modules:
+  bohrium-dataset:
+    tag: "数据集 (bohrium-dataset)"
+    skill_doc: zh/bohrium-dataset/SKILL.md
+    path_prefixes: ["/openapi/v2/ds/"]
+    team: ""
+    owner: ""
+    contact: ""
+    service_repo: ""
+    oncall: ""
+
+  bohrium-file:
+    tag: "文件盘 (bohrium-file)"
+    skill_doc: zh/bohrium-file/SKILL.md
+    path_prefixes: ["/openapi/v1/file/", "/openapi/v2/file/", "/openapi/v1/ak/get"]
+    team: ""
+    owner: ""
+    contact: ""
+    service_repo: ""
+    oncall: ""
+
+  bohrium-job:
+    tag: "计算任务 (bohrium-job)"
+    skill_doc: zh/bohrium-job/SKILL.md
+    path_prefixes: ["/openapi/v1/job/", "/openapi/v1/job_group/"]
+    team: ""
+    owner: ""
+    contact: ""
+    service_repo: ""
+    oncall: ""
+
+  bohrium-knowledge-base:
+    tag: "知识库 (bohrium-knowledge-base)"
+    skill_doc: zh/bohrium-knowledge-base/SKILL.md
+    path_prefixes: ["/openapi/v2/knowledge/"]
+    team: ""
+    owner: ""
+    contact: ""
+    service_repo: ""
+    oncall: ""
+
+  bohrium-lkm:
+    tag: "大知识模型 (bohrium-lkm)"
+    skill_doc: zh/bohrium-lkm/SKILL.md
+    path_prefixes: ["/openapi/v1/lkm/"]
+    team: ""
+    owner: ""
+    contact: ""
+    service_repo: ""
+    oncall: ""
+
+  bohrium-mentor:
+    tag: "AI 科学小导师 (bohrium-mentor)"
+    skill_doc: zh/bohrium-mentor/SKILL.md
+    path_prefixes: ["/openapi/v2/sigma-search/"]
+    team: ""
+    owner: ""
+    contact: ""
+    service_repo: ""
+    oncall: ""
+
+  bohrium-node:
+    tag: "开发节点 (bohrium-node)"
+    skill_doc: zh/bohrium-node/SKILL.md
+    path_prefixes: ["/openapi/v2/node/"]
+    team: ""
+    owner: ""
+    contact: ""
+    service_repo: ""
+    oncall: ""
+
+  bohrium-paper-search:
+    tag: "论文与专利搜索 (bohrium-paper-search)"
+    skill_doc: zh/bohrium-paper-search/SKILL.md
+    path_prefixes: ["/openapi/v2/paper/"]
+    team: ""
+    owner: ""
+    contact: ""
+    service_repo: ""
+    oncall: ""
+
+  bohrium-pdf-parser:
+    tag: "PDF 解析 (bohrium-pdf-parser)"
+    skill_doc: zh/bohrium-pdf-parser/SKILL.md
+    path_prefixes: ["/openapi/v2/parse/"]
+    team: ""
+    owner: ""
+    contact: ""
+    service_repo: ""
+    oncall: ""
+
+  bohrium-project:
+    tag: "项目管理 (bohrium-project)"
+    skill_doc: zh/bohrium-project/SKILL.md
+    path_prefixes: ["/openapi/v2/project/"]
+    team: ""
+    owner: ""
+    contact: ""
+    service_repo: ""
+    oncall: ""
+
+  bohrium-image:
+    tag: "容器镜像 (bohrium-image)"
+    skill_doc: zh/bohrium-image/SKILL.md
+    path_prefixes: ["/openapi/v2/image/"]
+    team: ""
+    owner: ""
+    contact: ""
+    service_repo: ""
+    oncall: ""
+
+  bohrium-scholar-search:
+    tag: "学者搜索 (bohrium-scholar-search)"
+    skill_doc: zh/bohrium-scholar-search/SKILL.md
+    path_prefixes: ["/openapi/v2/paper-server/"]
+    team: ""
+    owner: ""
+    contact: ""
+    service_repo: ""
+    oncall: ""
+
+  bohrium-sciencepedia:
+    tag: "科学百科 (bohrium-sciencepedia)"
+    skill_doc: zh/bohrium-sciencepedia/SKILL.md
+    path_prefixes: ["/openapi/v2/literature-sage/wiki_v2/"]
+    team: ""
+    owner: ""
+    contact: ""
+    service_repo: ""
+    oncall: ""
+
+  bohrium-tools:
+    tag: "科学工具库 (bohrium-tools)"
+    skill_doc: zh/bohrium-tools/SKILL.md
+    path_prefixes: ["/openapi/v2/literature-sage/tool/"]
+    team: ""
+    owner: ""
+    contact: ""
+    service_repo: ""
+    oncall: ""
+
+  bohrium-web-search:
+    tag: "网页搜索 (bohrium-web-search)"
+    skill_doc: zh/bohrium-web-search/SKILL.md
+    path_prefixes: ["/openapi/v2/search/web"]
+    team: ""
+    owner: ""
+    contact: ""
+    service_repo: ""
+    oncall: ""

--- a/tools/owners_table.py
+++ b/tools/owners_table.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""owners_table — 从 owners.yaml 渲染「认领表」，可直接粘进群里让各团队认领。
+
+用法:
+    python3 tools/owners_table.py            # markdown 表格
+    python3 tools/owners_table.py --todo      # 只列尚未认领的模块
+"""
+import sys, os, yaml
+
+REG = os.path.join(os.path.dirname(__file__), "..", "docs", "api", "owners.yaml")
+
+
+def main():
+    todo_only = "--todo" in sys.argv[1:]
+    with open(REG, encoding="utf-8") as f:
+        modules = yaml.safe_load(f)["modules"]
+
+    rows = []
+    for mod, info in modules.items():
+        claimed = bool(info.get("team") or info.get("owner"))
+        if todo_only and claimed:
+            continue
+        rows.append((
+            mod,
+            " ".join(info.get("path_prefixes", [])),
+            info.get("team") or "❓待认领",
+            info.get("owner") or "❓",
+            info.get("contact") or "",
+            info.get("service_repo") or "",
+        ))
+
+    print("| 模块 | 路径前缀 | 团队 | 负责人 | 联系方式(飞书/邮箱) | 后端仓库 |")
+    print("|------|----------|------|--------|----------------------|----------|")
+    for r in rows:
+        print("| " + " | ".join(r) + " |")
+
+    unclaimed = sum(1 for _, i in modules.items() if not (i.get("team") or i.get("owner")))
+    print(f"\n> 共 {len(modules)} 个模块，{unclaimed} 个待认领。认领方式：改 "
+          "`docs/api/owners.yaml` 里对应模块的 team/owner/contact/service_repo 并提 PR，"
+          "或在群里回复由维护者代填。")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/whoowns.py
+++ b/tools/whoowns.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""whoowns — 从接口路径或一段日志定位负责模块与团队。
+
+用法:
+    python3 tools/whoowns.py "/openapi/v2/parse/get-result"
+    python3 tools/whoowns.py "500 error at POST /openapi/v2/knowledge/file/submit ..."
+    echo "<日志>" | python3 tools/whoowns.py            # 从 stdin 读
+    python3 tools/whoowns.py --json "/openapi/v1/lkm/search"   # 机读输出
+
+按 path_prefixes 做「最长前缀匹配」，未命中则报告 unknown。
+注册表: docs/api/owners.yaml
+"""
+import sys, os, re, json
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("需要 PyYAML：pip install pyyaml")
+
+REG = os.path.join(os.path.dirname(__file__), "..", "docs", "api", "owners.yaml")
+PATH_RE = re.compile(r"/openapi/[A-Za-z0-9_./{}-]+")
+
+
+def load_modules():
+    with open(REG, encoding="utf-8") as f:
+        return yaml.safe_load(f)["modules"]
+
+
+def extract_path(text):
+    m = PATH_RE.search(text)
+    return m.group(0) if m else text.strip()
+
+
+def match(path, modules):
+    best, best_len = None, -1
+    for name, info in modules.items():
+        for pref in info.get("path_prefixes", []):
+            if path.startswith(pref) and len(pref) > best_len:
+                best, best_len = (name, info), len(pref)
+    return best
+
+
+def main():
+    args = [a for a in sys.argv[1:] if a != "--json"]
+    as_json = "--json" in sys.argv[1:]
+    raw = " ".join(args) if args else sys.stdin.read()
+    if not raw.strip():
+        sys.exit("用法: whoowns.py \"<路径或日志>\"")
+    path = extract_path(raw)
+    modules = load_modules()
+    hit = match(path, modules)
+    if not hit:
+        out = {"path": path, "module": None, "message": "未匹配到任何模块，请检查路径或补充 owners.yaml"}
+        print(json.dumps(out, ensure_ascii=False) if as_json else out["message"])
+        sys.exit(2)
+    name, info = hit
+    result = {
+        "path": path, "module": name, "tag": info.get("tag"),
+        "team": info.get("team") or "(未认领)",
+        "owner": info.get("owner") or "(未认领)",
+        "contact": info.get("contact") or "",
+        "service_repo": info.get("service_repo") or "",
+        "oncall": info.get("oncall") or "",
+        "skill_doc": info.get("skill_doc"),
+    }
+    if as_json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        print(f"路径:      {result['path']}")
+        print(f"模块:      {result['module']}  [{result['tag']}]")
+        print(f"团队/负责人: {result['team']} / {result['owner']}")
+        if result["contact"]:
+            print(f"联系方式:  {result['contact']}")
+        if result["service_repo"]:
+            print(f"后端仓库:  {result['service_repo']}")
+        if result["oncall"]:
+            print(f"值班:      {result['oncall']}")
+        print(f"契约文档:  {result['skill_doc']}  (git blame 可查最近改动人)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 目标

给 OpenAPI SSOT 加一条「谁改契约、谁负责」的认责链路，并顺带规范化 `openapi.json`。

## 改动

| 文件 | 内容 |
|------|------|
| `.github/CODEOWNERS` | 触及 `zh|en/<skill>/SKILL.md` 的 PR 自动请求对应团队 review（现为占位团队，待各团队替换为真实 `@org/team`） |
| `docs/api/owners.yaml` | 模块注册表：`path_prefixes` + `team/owner/contact/service_repo/oncall`，认领即填 |
| `tools/whoowns.py` | 按最长前缀把「日志路径」→ 模块/团队/契约文档（`--json` 便于 Agent 调用） |
| `tools/owners_table.py` | 生成认责表 |
| `docs/api/openapi.json` | 每个 tag 注入 `x-owner`；规范化参数类型/required、summary、精简冗余 response、统一路径参数命名（`{id}`→`{dataset_id}`/`{project_id}`） |
| `docs/api/README.md` | 新增「认责与追溯」 |
| `.gitignore` | 忽略 `_ref/` 与根 `bohrctl/`（参考源码克隆，**含生产 AccessKey，禁止提交**） |

## 校验

- `openapi.json` JSON valid、`owners.yaml` YAML valid、`tools/*.py` 编译通过
- `python3 tools/whoowns.py "/openapi/v1/job/list"` → 正确定位到 `bohrium-job`

## ⚠️ 与 #18 的关系

本 PR 与 #18（补充提交任务接口）都改 `openapi.json`，**会冲突**。本 PR 是全量结构化改动，建议**先合本 PR，再 rebase #18**（#18 只是在末尾追加 3 个 job 接口，rebase 成本低）。
