### PR TITLE
docs(api): 新增「科学导航 (bohrium-navigator)」接口分组

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -71,6 +71,10 @@
     {
       "name": "网页搜索 (bohrium-web-search)",
       "description": "网页搜索 — 代理 searchapi.io 做开放互联网检索。免费。"
+    },
+    {
+      "name": "科学导航 (bohrium-navigator)",
+      "description": "经典 Sigma 文献智能搜索（sigma-search v1）— 创建会话提问、多轮追问、获取 AI 总结与相关文献列表、查询问答记录。与 bohrium-mentor（v4 深度推理 SSE）同源不同代，能力互补。"
     }
   ],
   "paths": {
@@ -6321,6 +6325,2466 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v1/sigma-search/api/v1/ai_search/sessions": {
+      "post": {
+        "tags": [
+          "科学导航 (bohrium-navigator)"
+        ],
+        "summary": "创建新的搜索会话",
+        "description": "创建新的搜索会话，并且得到此次会话的uuid\n  - 输入你的问题（如 \"Transformer在视频处理中的应用\"）\n  - 返回 uuid",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "title": "查询语句"
+                  },
+                  "model": {
+                    "type": "string",
+                    "title": "模型配置",
+                    "enum": [
+                      "auto",
+                      "pro",
+                      "reason"
+                    ]
+                  },
+                  "discipline": {
+                    "type": "string",
+                    "enum": [
+                      "All",
+                      "NS",
+                      "ET",
+                      "LS",
+                      "PSS"
+                    ],
+                    "title": "学科分类"
+                  },
+                  "resource_id_list": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "分子图资源"
+                  }
+                },
+                "required": [
+                  "query",
+                  "model",
+                  "discipline",
+                  "resource_id_list"
+                ]
+              },
+              "example": {
+                "query": "string",
+                "model": "auto",
+                "discipline": "All",
+                "resource_id_list": [
+                  "string"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "uuid": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "share": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "uuid",
+                        "title",
+                        "share"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "code",
+                    "data"
+                  ]
+                },
+                "example": {
+                  "code": 0,
+                  "data": {
+                    "uuid": "ab91eaa9-e7c9-4b48-b2cc-b6fd49556b50",
+                    "title": "Transformer在视频处理中的应用",
+                    "share": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "科学导航 (bohrium-navigator)"
+        ],
+        "summary": "获取问答记录",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v1/sigma-search/api/v1/ai_search/sessions/{uuid}": {
+      "get": {
+        "tags": [
+          "科学导航 (bohrium-navigator)"
+        ],
+        "summary": "获取搜索详情",
+        "description": "-  根据 UUID 获取 Session 详情\n  - 使用创建新的搜索会话接口返回的 uuid 调用该接口，获取 questions[0].id，即 queryID",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "required": true,
+            "example": "da63489c-f0af-44fb-8a4b-93326c9a1fdf",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "uuid": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string"
+                        },
+                        "share": {
+                          "type": "boolean"
+                        },
+                        "shareLink": {
+                          "type": "string"
+                        },
+                        "model": {
+                          "type": "string"
+                        },
+                        "modelType": {
+                          "type": "string"
+                        },
+                        "questions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer"
+                              },
+                              "query": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "type": "string"
+                              },
+                              "lastAnswerID": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        },
+                        "resources": {
+                          "type": "null"
+                        },
+                        "createTime": {
+                          "type": "string"
+                        },
+                        "permission": {
+                          "type": "integer"
+                        },
+                        "discipline": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "uuid",
+                        "title",
+                        "status",
+                        "share",
+                        "shareLink",
+                        "model",
+                        "modelType",
+                        "questions",
+                        "resources",
+                        "createTime",
+                        "permission",
+                        "discipline"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "code",
+                    "data"
+                  ]
+                },
+                "example": {
+                  "code": 0,
+                  "data": {
+                    "uuid": "da63489c-f0af-44fb-8a4b-93326c9a1fdf",
+                    "title": "Transformer在视频处理中的应用",
+                    "status": "",
+                    "share": false,
+                    "shareLink": "",
+                    "model": "qwen",
+                    "modelType": "keywords",
+                    "questions": [
+                      {
+                        "id": 6486,
+                        "query": "Transformer在视频处理中的应用",
+                        "status": "succeeded",
+                        "lastAnswerID": 7367
+                      }
+                    ],
+                    "resources": null,
+                    "createTime": "2025-04-27T15:40:27+08:00",
+                    "permission": 2,
+                    "discipline": "All"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v1/sigma-search/api/v1/ai_search/sessions/{uuid}/questions": {
+      "post": {
+        "tags": [
+          "科学导航 (bohrium-navigator)"
+        ],
+        "summary": "文献搜索追问",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "query"
+                ]
+              },
+              "example": {
+                "query": "Transformer在音频处理中的应用"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v1/sigma-search/api/v1/ai_search/questions/{queryId}": {
+      "get": {
+        "tags": [
+          "科学导航 (bohrium-navigator)"
+        ],
+        "summary": "获得总结内容",
+        "parameters": [
+          {
+            "name": "queryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v1/sigma-search/api/v1/ai_search/questions/{queryID}/stream": {
+      "get": {
+        "tags": [
+          "科学导航 (bohrium-navigator)"
+        ],
+        "summary": "获取流式输出",
+        "parameters": [
+          {
+            "name": "queryID",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi/v1/sigma-search/api/v1/ai_search/questions/{queryID}/papers": {
+      "get": {
+        "tags": [
+          "科学导航 (bohrium-navigator)"
+        ],
+        "summary": "获取问题相关文献",
+        "description": "- 使用 queryID 请求该接口，获取与该问题高度相关的论文列表\n提示：queryID 就是搜索详情接口中使用的 /questions/{queryID}/papers 中的 ID。",
+        "parameters": [
+          {
+            "name": "queryID",
+            "in": "path",
+            "required": true,
+            "example": "6486",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "example": "RelevanceScore",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "list": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "sequenceId": {
+                                "type": "integer"
+                              },
+                              "author": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "link": {
+                                "type": "string"
+                              },
+                              "source": {
+                                "type": "string"
+                              },
+                              "sourceZh": {
+                                "type": "string"
+                              },
+                              "abstract": {
+                                "type": "string"
+                              },
+                              "abstractZh": {
+                                "type": "string"
+                              },
+                              "title": {
+                                "type": "string"
+                              },
+                              "titleZh": {
+                                "type": "string"
+                              },
+                              "doi": {
+                                "type": "string"
+                              },
+                              "bohriumId": {
+                                "type": "string"
+                              },
+                              "publicationId": {
+                                "type": "integer"
+                              },
+                              "publicationCover": {
+                                "type": "string"
+                              },
+                              "publicationDate": {
+                                "type": "string"
+                              },
+                              "journal": {
+                                "type": "string"
+                              },
+                              "arxiv": {
+                                "type": "string"
+                              },
+                              "aiSummarize": {
+                                "type": "string"
+                              },
+                              "openAccess": {
+                                "type": "string"
+                              },
+                              "pdfFlag": {
+                                "type": "boolean"
+                              },
+                              "pieces": {
+                                "type": "string"
+                              },
+                              "sortScore": {
+                                "type": "number"
+                              },
+                              "relevanceScore": {
+                                "type": "number"
+                              },
+                              "publicationScore": {
+                                "type": "integer"
+                              },
+                              "impactFactor": {
+                                "type": "number"
+                              },
+                              "impactFactorScore": {
+                                "type": "number"
+                              },
+                              "citationNums": {
+                                "type": "integer"
+                              },
+                              "fullText": {
+                                "type": "string"
+                              },
+                              "figures": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "figureId": {
+                                      "type": "string"
+                                    },
+                                    "imageUrl": {
+                                      "type": "string"
+                                    },
+                                    "enExplain": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "figureId",
+                                    "imageUrl",
+                                    "enExplain"
+                                  ]
+                                }
+                              }
+                            },
+                            "required": [
+                              "sequenceId",
+                              "author",
+                              "link",
+                              "source",
+                              "sourceZh",
+                              "abstract",
+                              "abstractZh",
+                              "title",
+                              "titleZh",
+                              "doi",
+                              "bohriumId",
+                              "publicationId",
+                              "publicationCover",
+                              "publicationDate",
+                              "journal",
+                              "arxiv",
+                              "aiSummarize",
+                              "openAccess",
+                              "pdfFlag",
+                              "pieces",
+                              "sortScore",
+                              "relevanceScore",
+                              "publicationScore",
+                              "impactFactor",
+                              "impactFactorScore",
+                              "citationNums",
+                              "fullText",
+                              "figures"
+                            ]
+                          }
+                        },
+                        "sourceList": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "logId": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "list",
+                        "sourceList",
+                        "logId"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "code",
+                    "data"
+                  ]
+                },
+                "example": {
+                  "code": 0,
+                  "data": {
+                    "list": [
+                      {
+                        "sequenceId": 1,
+                        "author": [
+                          "Omar Elharrouss",
+                          "Rafat Damseh",
+                          "Abdelkader Nasreddine Belkacem",
+                          "Elarbi Badidi",
+                          "Abderrahmane Lakas"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Image inpainting is currently a hot topic within the field of computer vision. It offers a viable solution for various applications, including photographic restoration, video editing, and medical imaging. Deep learning advancements, notably convolutional neural networks (CNNs) and generative adversarial networks (GANs), have significantly enhanced the inpainting task with an improved capability to fill missing or damaged regions in an image or a video through the incorporation of contextually appropriate details. These advancements have improved other aspects, including efficiency, information preservation, and achieving both realistic textures and structures. Recently, Vision Transformers (ViTs) have been exploited and offer some improvements to image or video inpainting. The advent of transformer-based architectures, which were initially designed for natural language processing, has also been integrated into computer vision tasks. These methods utilize self-attention mechanisms that excel in capturing long-range dependencies within data; therefore, they are particularly effective for tasks requiring a comprehensive understanding of the global context of an image or video. In this paper, we provide a comprehensive review of the current image/video inpainting approaches, with a specific focus on Vision Transformer (ViT) techniques, with the goal to highlight the significant improvements and provide a guideline for new researchers in the field of image/video inpainting using vision transformers. We categorized the transformer-based techniques by their architectural configurations, types of damage, and performance metrics. Furthermore, we present an organized synthesis of the current challenges, and suggest directions for future research in the field of image or video inpainting.",
+                        "abstractZh": "",
+                        "title": "Transformer-based image and video inpainting: current challenges and future directions",
+                        "titleZh": "",
+                        "doi": "10.1007/s10462-024-11075-9",
+                        "bohriumId": "1114167914551836729",
+                        "publicationId": 2496,
+                        "publicationCover": "https://assets.catalystplus.cn/journal_cover/2496.png",
+                        "publicationDate": "2025-02-05",
+                        "journal": "Artificial Intelligence Review",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.6699621507977884,
+                        "relevanceScore": 0.6334102749824524,
+                        "publicationScore": 1,
+                        "impactFactor": 10.7,
+                        "impactFactorScore": 0.44957983193277307,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 2,
+                        "author": [
+                          "Salman Khan",
+                          "Muzammal Naseer",
+                          "Munawar Hayat",
+                          "Syed Waqas Zamir",
+                          "Fahad Shahbaz Khan",
+                          "Mubarak Shah"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Astounding results from Transformer models on natural language tasks have intrigued the vision community to study their application to computer vision problems. Among their salient benefits, Transformers enable modeling long dependencies between input sequence elements and support parallel processing of sequence as compared to recurrent networks e.g. , Long short-term memory (LSTM). Different from convolutional networks, Transformers require minimal inductive biases for their design and are naturally suited as set-functions. Furthermore, the straightforward design of Transformers allows processing multiple modalities ( e.g. , images, videos, text and speech) using similar processing blocks and demonstrates excellent scalability to very large capacity networks and huge datasets. These strengths have led to exciting progress on a number of vision tasks using Transformer networks. This survey aims to provide a comprehensive overview of the Transformer models in the computer vision discipline. We start with an introduction to fundamental concepts behind the success of Transformers i.e., self-attention, large-scale pre-training, and bidirectional feature encoding. We then cover extensive applications of transformers in vision including popular recognition tasks ( e.g. , image classification, object detection, action recognition, and segmentation), generative modeling, multi-modal tasks ( e.g. , visual-question answering, visual reasoning, and visual grounding), video processing ( e.g. , activity recognition, video forecasting), low-level vision ( e.g. , image super-resolution, image enhancement, and colorization) and 3D analysis ( e.g. , point cloud classification and segmentation). We compare the respective advantages and limitations of popular techniques both in terms of architectural design and their experimental value. Finally, we provide an analysis on open research directions and possible future works. We hope this effort will ignite further interest in the community to solve current challenges towards the application of transformer models in computer vision.",
+                        "abstractZh": "Transformer模型在自然语言任务中取得的惊人成果引发了视觉领域的关注，促使人们研究其在计算机视觉问题中的应用。与循环网络（例如长短期记忆网络，LSTM）相比，Transformer具有显著优势，它能够对输入序列元素之间的长距离依赖关系进行建模，并支持序列的并行处理。与卷积网络不同，Transformer在设计时所需的归纳偏置极少，天生适合作为集合函数。此外，Transformer的设计简单直接，能够使用相似的处理模块处理多种模态（如图像、视频、文本和语音），并在扩展到非常大容量的网络和海量数据集时表现出出色的可扩展性。这些优势使得Transformer网络在许多视觉任务中取得了令人兴奋的进展。本综述旨在全面概述计算机视觉领域中的Transformer模型。我们首先介绍Transformer成功背后的基本概念，即自注意力机制、大规模预训练和双向特征编码。然后，我们涵盖Transformer在视觉领域的广泛应用，包括流行的识别任务（如图像分类、目标检测、动作识别和分割）、生成建模、多模态任务（如视觉问答、视觉推理和视觉定位）、视频处理（如活动识别、视频预测）、低级视觉（如图像超分辨率、图像增强和图像上色）以及3D分析（如点云分类和分割）。我们从架构设计和实验价值两方面比较了流行技术各自的优缺点。最后，我们对开放的研究方向和可能的未来工作进行了分析。我们希望这项工作能够激发社区对解决Transformer模型在计算机视觉应用中当前挑战的进一步兴趣。 ",
+                        "title": "Transformers in Vision: A Survey",
+                        "titleZh": "视觉领域中的Transformer：综述",
+                        "doi": "10.1145/3505244",
+                        "bohriumId": "814629353752100865",
+                        "publicationId": 2425,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2425.png",
+                        "publicationDate": "2022-01-06",
+                        "journal": "ACM Computing Surveys",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.6641724684374801,
+                        "relevanceScore": 0.6233768463134766,
+                        "publicationScore": 0.4507317073170732,
+                        "impactFactor": 23.8,
+                        "impactFactorScore": 1,
+                        "citationNums": 30,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "814629353752100865_fig8_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/2425/814629353752100865/814629353752100865_fig8_1.png",
+                            "enExplain": "This image presents a detailed comparison of several vision - language pre - training models, organized in a tabular format with clear visual cues for different components.\n\n### 1. Model Categories and Sub - models\nThe table is divided into two main sections: \"Single - stream Transformers\" and \"Multi - stream Transformers\", each containing several sub - models.\n\n#### Single - stream Transformers\n- **(a) UNITER**: Focuses on Masked Language & Region Modeling - Visual, with tasks such as Visual - Language Pre - training. It uses a Multi - layer Transformer architecture.\n- **(b) OSCAR**: Incorporates Contrastive Learning - Masked Token Loss on Image - Text Pairs. Also based on a Multi - layer Transformer.\n- **(c) VideoBERT**: Deals with Masked Video and Language Token Modeling, leveraging a Multi - layer Transformer structure.\n- **(d) UniLM - VL**: Performs Masked Language Modeling - Masked Object, using a Single - Stream Architecture.\n- **(e) ViLBERT**: Conducts Masked Language Modeling and is designed for Image - Text Understanding. It uses a Multi - layer Transformer.\n- **(f) VL - BERT**: Engages in Masked Language Modeling and Masked Object Prediction, with a Multi - layer Transformer backbone.\n\n#### Multi - stream Transformers\n- **(g) LXMERT**: Focuses on Multiple Tasks like Object - Relationship Modeling, Image Question Answering, etc. It has both Cross - modality Transformer and Intra - modality Transformer for Object Relationship and Language processing respectively.\n- **(h) VILBERT**: Performs Masked Language Modeling and Masked Object Prediction, with separate streams for language and visual processing connected by Cross - modality Transformers.\n- **(i) PEMT**: Involves Masked Embedding Mining and uses Cross - modality Transformers for audio - visual - language interactions.\n\n### 2. Components and Annotations\n- **Loss functions**: Represented by green squares in the table. These are the objective functions that the models aim to optimize during training. For example, in UNITER, the loss functions are related to its masked language and region modeling tasks.\n- **Transformer blocks**: Indicated by blue squares. These are the fundamental building blocks of the models, providing the sequential processing power for both language and visual features.\n- **Language Tokens**: Marked with yellow squares. These are the discrete units of language that the models process, such as words or sub - words in a text sequence.\n- **Visual/Audio Features**: Represented by orange squares. For vision - language models, these are the features extracted from images or videos (in the case of video - related models), and for audio - involved models like PEMT, audio features are also considered.\n\n### 3. Overall Purpose\nThe table serves as a comprehensive reference for understanding the key aspects of different vision - language pre - training models. It highlights the architectural differences (single - stream vs. multi - stream), the specific tasks they are designed for, and the main components that contribute to their functionality. This visual representation helps researchers and practitioners quickly compare and contrast these models, facilitating the selection of appropriate models for specific vision - language tasks. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 3,
+                        "author": [
+                          "Kai Han",
+                          "Yunhe Wang",
+                          "Hanting Chen",
+                          "Xinghao Chen",
+                          "Jianyuan Guo",
+                          "Zhenhua Liu",
+                          "Yehui Tang",
+                          "An Xiao",
+                          "Chunjing Xu",
+                          "Yixing Xu",
+                          "Zhaohui Yang",
+                          "Yiman Zhang",
+                          "Dacheng Tao"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Transformer, first applied to the field of natural language processing, is a type of deep neural network mainly based on the self-attention mechanism. Thanks to its strong representation capabilities, researchers are looking at ways to apply transformer to computer vision tasks. In a variety of visual benchmarks, transformer-based models perform similar to or better than other types of networks such as convolutional and recurrent neural networks. Given its high performance and less need for vision-specific inductive bias, transformer is receiving more and more attention from the computer vision community. In this paper, we review these vision transformer models by categorizing them in different tasks and analyzing their advantages and disadvantages. The main categories we explore include the backbone network, high/mid-level vision, low-level vision, and video processing. We also include efficient transformer methods for pushing transformer into real device-based applications. Furthermore, we also take a brief look at the self-attention mechanism in computer vision, as it is the base component in transformer. Toward the end of this paper, we discuss the challenges and provide several further research directions for vision transformers.",
+                        "abstractZh": "Transformer最早应用于自然语言处理领域，是一种主要基于自注意力机制的深度神经网络。由于其强大的表示能力，研究人员正在探索将Transformer应用于计算机视觉任务的方法。在各种视觉基准测试中，基于Transformer的模型表现与卷积神经网络和循环神经网络等其他类型的网络相似或更好。鉴于其高性能以及对视觉特定归纳偏差的需求较少，Transformer正受到计算机视觉社区越来越多的关注。在本文中，我们通过在不同任务中对这些视觉Transformer模型进行分类并分析其优缺点来对它们进行综述。我们探索的主要类别包括骨干网络、高/中级视觉、低级视觉和视频处理。我们还包括将Transformer推向基于实际设备的应用的高效Transformer方法。此外，我们还简要介绍了计算机视觉中的自注意力机制，因为它是Transformer的基础组件。在本文结尾，我们讨论了挑战，并为视觉Transformer提供了几个进一步的研究方向。 ",
+                        "title": "A Survey on Vision Transformer",
+                        "titleZh": "关于视觉Transformer的综述",
+                        "doi": "10.1109/tpami.2022.3152247",
+                        "bohriumId": "812834959394865153",
+                        "publicationId": 2429,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2429.png",
+                        "publicationDate": "2022-01-01",
+                        "journal": "IEEE Transactions on Pattern Analysis and Machine Intelligence",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "As such, a survey of the existing works is urgent and would be beneficial for the community. In this paper, we focus on providing a comprehensive overview of the recent advances in vision transformers and discuss the potential directions for further improvement.To facilitate future research on different topics, we categorize the transformer models by their application scenarios, as listed in Table 1. The main categories include backbone network, high/mid-level vision, low-level vision, and video processing.High-level vision deals with the interpretation and use of what is seen in the image [21], whereas mid-level vision deals with how this information is organized into what we experience as objects and surfaces [22]. Given the gap between high- and mid-level vision is becoming more obscure in DNN-based vision systems [23], [24], we treat them as a single category here.A few examples of transformer models that address these high/mid-level vision tasks include DETR [16], deformable DETR [17] for object detection, and Max-DeepLab [25] for segmentation. Low-level image processing mainly deals with extracting descriptions from images (such descriptions are usually represented as images themselves) [26].Typical applications of low-level image processing include super-resolution, image denoising, and style transfer. At present, only a few works [19], [27] in low-level vision use transformers, creating the need for further investigation.Another category is video processing, which is an important part in both computer vision and image-based tasks. Due to the sequential property of video, transformer is inherently well suited for use on video tasks [20], [28], in which it is beginning to perform on par with conventional CNNs and RNNs.Here, we survey the works associated with transformer-based visual models in order to track the progress in this field. Fig.1 shows the development timeline of vision transformer – undoubtedly, there will be many more milestones in the future.TABLE 1 Representative Works of Vision Transformers Fig. 1.Key milestones in the development of transformer.The vision transformer models are marked in red.Show AllThe rest of the paper is organized as follows.Section II discusses the formulation of the standard transformer and the self-attention mechanism. Section III is the main part of the paper, in which we summarize the vision transformer models on backbone, high/mid-level vision, low-level vision, and video tasks.We also briefly describe efficient transformer methods, as they are closely related to our main topic. In the final section, we give our conclusion and discuss several research directions and challenges.Due to the page limit, we describe the methods of transformer in NLP in the supplemental material, which can be found on the Computer Society Digital Library at http://doi. ieeecomputersociety.org/10.1109/TPAMI.2022.3152247, as the research experience may be beneficial for vision tasks.",
+                        "sortScore": 0.5994446455698846,
+                        "relevanceScore": 0.5583269596099854,
+                        "publicationScore": 0.4482926829268293,
+                        "impactFactor": 20.8,
+                        "impactFactorScore": 0.8739495798319328,
+                        "citationNums": 745,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 4,
+                        "author": [
+                          "Ludan Ruan",
+                          "Qin Jin"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Inspired by the success of transformer-based pre-training methods on natural language tasks and further computer vision tasks, researchers have started to apply transformer to video processing. This survey aims to provide a comprehensive overview of transformer-based pre-training methods for Video-Language learning. We first briefly introduce the transformer structure as the background knowledge, including attention mechanism, position encoding etc. We then describe the typical paradigm of pre-training &amp; fine-tuning on Video-Language processing in terms of proxy tasks, downstream tasks and commonly used video datasets. Next, we categorize transformer models into Single-Stream and Multi-Stream structures, highlight their innovations and compare their performances. Finally, we analyze and discuss the current challenges and possible future research directions for Video-Language pre-training.",
+                        "abstractZh": "受到基于 Transformer 的自然语言任务和进一步计算机视觉任务的预训练方法成功的启发，研究人员开始将 Transformer 应用于视频处理。本调查旨在全面概述基于 Transformer 的视频语言学习预训练方法。我们首先简要介绍了 Transformer 结构作为背景知识，包括注意力机制、位置编码等。然后我们从代理任务、下游任务和常用任务方面描述了视频语言处理预训练和微调的典型范例。视频数据集。接下来，我们将 Transformer 模型分为单流和多流结构，重点介绍它们的创新并比较它们的性能。最后，我们分析和讨论了视频语言预训练当前的挑战和未来可能的研究方向。",
+                        "title": "Survey: Transformer based video-language pre-training",
+                        "titleZh": "调查：基于 Transformer 的视频语言预训练",
+                        "doi": "10.1016/j.aiopen.2022.01.001",
+                        "bohriumId": "814533122153512961",
+                        "publicationId": 79372,
+                        "publicationCover": "https://assets.catalystplus.cn/journal_cover/79372.png",
+                        "publicationDate": "2022-01-01",
+                        "journal": "AI Open",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.589347631361828,
+                        "relevanceScore": 0.7549149990081787,
+                        "publicationScore": 0.4482926829268293,
+                        "impactFactor": 0,
+                        "impactFactorScore": 0.23370037670240518,
+                        "citationNums": 1,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 5,
+                        "author": [
+                          "Nikos Lazaridis",
+                          "Kostas Georgiadis",
+                          "Fotis Kalaganis",
+                          "Giorgos Kordopatis-Zilos",
+                          "Symeon Papadopoulos",
+                          "Spiros Nikolopoulos",
+                          "Ioannis Kompatsiaris"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "The Transformer revolutionized Natural Language Processing and Computer Vision by effectively capturing contextual relationships in sequential data through its attention mechanism. While Transformers have been explored sufficiently in traditional computer vision tasks such as image classification, their application to more intricate tasks, such as Video Saliency Prediction (VSP), remains limited. Video saliency prediction is the task of identifying the most visually salient regions in a video, which are likely to capture a viewer’s attention. In this study, we propose a pure transformer architecture named Temporal Visual Saliency Transformer (TempVST) for the VSP task. Our model leverages the Visual Saliency Transformer (VST) as a backbone, with the addition of a Transformer-based temporal module that can seamlessly transition diverse architectural frameworks from image to video domain, through the incorporation of temporal recurrences. Moreover, we demonstrate that transfer learning is viable in the context of VSP through Transformer architectures and helps reduce the duration of the training phase, leading to a reduction in the duration of the training phase by 41% and 45% in two different datasets. Our experiments were conducted on two benchmark datasets, DHF1K and LEDOV, and our results show that our network can compete with all other state-of-the-art models.",
+                        "abstractZh": "Transformer 通过其注意力机制有效捕获序列数据中的上下文关系，彻底改变了自然语言处理和计算机视觉。虽然 Transformer 在图像分类等传统计算机视觉任务中得到了充分的探索，但它们在视频显着性预测 (VSP) 等更复杂的任务中的应用仍然有限。视频显着性预测是识别视频中视觉上最显着的区域的任务，这些区域可能会吸引观看者的注意力。在本研究中，我们为 VSP 任务提出了一种名为 Temporal Visual Saliency Transformer (TempVST) 的纯 Transformer 架构。我们的模型利用视觉显着性转换器（VST）作为骨干，并添加了基于转换器的时间模块，该模块可以通过结合时间循环将不同的架构框架从图像无缝转换到视频域。此外，我们证明迁移学习通过 Transformer 架构在 VSP 环境中是可行的，并有助于减少训练阶段的持续时间，从而使两个不同数据集中的训练阶段持续时间分别减少 41% 和 45%。我们的实验是在两个基准数据集 DHF1K 和 LEDOV 上进行的，结果表明我们的网络可以与所有其他最先进的模型竞争。",
+                        "title": "The Visual Saliency Transformer Goes Temporal: TempVST for Video Saliency Prediction",
+                        "titleZh": "",
+                        "doi": "10.1109/access.2024.3436585",
+                        "bohriumId": "1055877793025359873",
+                        "publicationId": 2649,
+                        "publicationCover": "https://assets.catalystplus.cn/journal_cover/2649.png",
+                        "publicationDate": "2024-01-01",
+                        "journal": "IEEE Access",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.5791966742166299,
+                        "relevanceScore": 0.6495786309242249,
+                        "publicationScore": 0.8043902439024391,
+                        "impactFactor": 3.9,
+                        "impactFactorScore": 0.14285714285714285,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 6,
+                        "author": [
+                          "Anwaar Ulhaq"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Recognizing human actions in adverse lighting conditions presents significant challenges in computer vision, with wide-ranging applications in visual surveillance and nighttime driving. Existing methods tackle action recognition and dark enhancement separately, limiting the potential for end-to-end learning of spatiotemporal representations for video action classification. This paper introduces Dark Transformer, a novel video transformer-based approach for action recognition in low-light environments. Dark Transformer leverages spatiotemporal self-attention mechanisms in cross-domain settings to enhance cross-domain action recognition. By extending video transformers to learn cross-domain knowledge, Dark Transformer achieves state-of-the-art performance on benchmark action recognition datasets, including InFAR, XD145, and ARID. The proposed approach demonstrates significant promise in addressing the challenges of action recognition in adverse lighting conditions, offering practical implications for real-world applications.",
+                        "abstractZh": "在不利的照明条件下识别人类行为对计算机视觉提出了重大挑战，在视觉监控和夜间驾驶方面有着广泛的应用。现有方法分别处理动作识别和暗增强，限制了视频动作分类时空表示的端到端学习的潜力。本文介绍了 Dark Transformer，这是一种基于视频变压器的新型方法，用于低光环境下的动作识别。 Dark Transformer 利用跨域设置中的时空自注意力机制来增强跨域动作识别。通过扩展视频转换器来学习跨领域知识，Dark Transformer 在基准动作识别数据集（包括 InFAR、XD145 和 ARID）上实现了最先进的性能。所提出的方法在解决不利照明条件下的动作识别挑战方面展现了巨大的前景，为现实世界的应用提供了实际意义。",
+                        "title": "Dark Transformer: A Video Transformer for Action Recognition in the Dark",
+                        "titleZh": "Dark Transformer：用于黑暗中动作识别的视频 Transformer",
+                        "doi": "10.48550/arxiv.2407.12805",
+                        "bohriumId": "1022029229564362784",
+                        "publicationId": 108597,
+                        "publicationCover": "https://assets.catalystplus.cn/journal_cover/arxiv.png",
+                        "publicationDate": "2024-06-25",
+                        "journal": "Computer Vision and Pattern Recognition",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.5471593534788418,
+                        "relevanceScore": 0.5372841358184814,
+                        "publicationScore": 0.8902439024390244,
+                        "impactFactor": 0,
+                        "impactFactorScore": 0.23370037670240518,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 7,
+                        "author": [
+                          "Yanhao Jing",
+                          "Feng Wang"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Recently, inspired by the success of Transformer in natural language processing tasks, a number of works have attempted to apply Transformer-based models to video action recognition. Existing works only use one RGB stream as the input for Transformer. How to use multiple pathways and multiple streams with Transformer for action recognition has not been studied. To address this issue, we present a novel structure namely Two-Pathway Vision Transformer (TP-ViT). Two parallel spatial Transformer encoders are used as two pathways with different framerates and resolutions of the input video. The high-resolution pathway contains more spatial information, while the high-framerate pathway contains more temporal information. The two outputs are fused and fed into a temporal Transformer encoder for action recognition. Furthermore, we also fuse skeleton features into our model to get better results. Our experiments demonstrate that our proposed models achieve the state-of-the-art results on both the coarse-grained dataset Kinetics and the fine-grained dataset FineGym.",
+                        "abstractZh": "",
+                        "title": "TP-VIT: A Two-Pathway Vision Transformer for Video Action Recognition",
+                        "titleZh": "TP-VIT：用于视频动作识别的双路视觉转换器",
+                        "doi": "10.1109/icassp43922.2022.9747276",
+                        "bohriumId": "811909414784073730",
+                        "publicationId": 0,
+                        "publicationCover": "",
+                        "publicationDate": "2022-05-23",
+                        "journal": "ICASSP 2022   2022 IEEE International Conference on Acoustics, Speech and Signal Processing (ICASSP)",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.533012419269987,
+                        "relevanceScore": 0.6379335522651672,
+                        "publicationScore": 0.5175609756097561,
+                        "impactFactor": 0,
+                        "impactFactorScore": 0.23370037670240518,
+                        "citationNums": 10,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 8,
+                        "author": [
+                          "Tianyu Zhang",
+                          "Longhui Wei",
+                          "Lingxi Xie",
+                          "Zijie Zhuang",
+                          "Yongfei Zhang",
+                          "Bo Li",
+                          "Qi Tian"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Recently, the Transformer module has been transplanted from natural language processing to computer vision. This paper applies the Transformer to video-based person re-identification, where the key issue is to extract the discriminative information from a tracklet. We show that, despite the strong learning ability, the vanilla Transformer suffers from an increased risk of over-fitting, arguably due to a large number of attention parameters and insufficient training data. To solve this problem, we propose a novel pipeline where the model is pre-trained on a set of synthesized video data and then transferred to the downstream domains with the perception-constrained Spatiotemporal Transformer (STT) module and Global Transformer (GT) module. The derived algorithm achieves significant accuracy gain on three popular video-based person re-identification benchmarks, MARS, DukeMTMC-VideoReID, and LS-VID, especially when the training and testing data are from different domains. More importantly, our research sheds light on the application of the Transformer on highly-structured visual data.",
+                        "abstractZh": "最近，Transformer模块已经从自然语言处理移植到计算机视觉。本文将 Transformer 应用于基于视频的行人重识别，其中的关键问题是从轨迹中提取判别信息。我们发现，尽管普通 Transformer 具有很强的学习能力，但其过拟合的风险却增加了，这可能是由于大量的注意力参数和训练数据不足造成的。为了解决这个问题，我们提出了一种新颖的管道，其中模型在一组合成视频数据上进行预训练，然后使用感知约束的时空变换器（STT）模块和全局变换器（GT）模块转移到下游域。派生算法在三个流行的基于视频的行人重识别基准 MARS、DukeMTMC-VideoReID 和 LS-VID 上实现了显着的准确度提升，特别是当训练和测试数据来自不同领域时。更重要的是，我们的研究揭示了 Transformer 在高度结构化视觉数据上的应用。",
+                        "title": "Spatiotemporal Transformer for Video-based Person Re-identification",
+                        "titleZh": "用于基于视频的行人重新识别的时空转换器",
+                        "doi": "10.48550/arXiv.2103.16469",
+                        "bohriumId": "867752262686999221",
+                        "publicationId": 108597,
+                        "publicationCover": "https://assets.catalystplus.cn/journal_cover/arxiv.png",
+                        "publicationDate": "2021-03-30",
+                        "journal": "Computer Vision and Pattern Recognition",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.5328452617911956,
+                        "relevanceScore": 0.7057850360870361,
+                        "publicationScore": 0.3131707317073171,
+                        "impactFactor": 0,
+                        "impactFactorScore": 0.23370037670240518,
+                        "citationNums": 7,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 9,
+                        "author": [
+                          "Bolin Lai",
+                          "Miao Liu",
+                          "Fiona Ryan",
+                          "James M. Rehg"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Abstract Predicting human’s gaze from egocentric videos serves as a critical role for human intention understanding in daily activities. In this paper, we present the first transformer-based model to address the challenging problem of egocentric gaze estimation. We observe that the connection between the global scene context and local visual information is vital for localizing the gaze fixation from egocentric video frames. To this end, we design the transformer encoder to embed the global context as one additional visual token and further propose a novel global–local correlation module to explicitly model the correlation of the global token and each local token. We validate our model on two egocentric video datasets – EGTEA Gaze + and Ego4D. Our detailed ablation studies demonstrate the benefits of our method. In addition, our approach exceeds the previous state-of-the-art model by a large margin. We also apply our model to a novel gaze saccade/fixation prediction task and the traditional action recognition problem. The consistent gains suggest the strong generalization capability of our model. We also provide additional visualizations to support our claim that global–local correlation serves a key representation for predicting gaze fixation from egocentric videos. More details can be found in our website ( https://bolinlai.github.io/GLC-EgoGazeEst ).",
+                        "abstractZh": "摘要 从以自我为中心的视频中预测人类的目光对于人类日常活动中的意图理解至关重要。在本文中，我们提出了第一个基于变压器的模型来解决自我中心注视估计的挑战性问题。我们观察到，全局场景上下文和局部视觉信息之间的联系对于定位以自我为中心的视频帧中的注视固定至关重要。为此，我们设计了 Transformer 编码器，将全局上下文嵌入为一个额外的视觉标记，并进一步提出了一种新颖的全局-局部相关模块来显式建模全局标记和每个局部标记的相关性。我们在两个以自我为中心的视频数据集——EGTEA Gaze + 和 Ego4D 上验证了我们的模型。我们详细的消融研究证明了我们方法的优点。此外，我们的方法大大超过了之前最先进的模型。我们还将我们的模型应用于新颖的注视扫视/注视预测任务和传统的动作识别问题。一致的收益表明我们的模型具有很强的泛化能力。我们还提供了额外的可视化来支持我们的主张，即全局-局部相关性是预测自我中心视频注视固定的关键表示。更多详细信息可以在我们的网站 (https://bolinlai.github.io/GLC-EgoGazeEst) 中找到。",
+                        "title": "In the Eye of Transformer: Global–Local Correlation for Egocentric Gaze Estimation and Beyond",
+                        "titleZh": "在Transformer视角下：用于自我中心注视估计及其他的全局-局部相关性",
+                        "doi": "10.1007/s11263-023-01879-7",
+                        "bohriumId": "949269914999324923",
+                        "publicationId": 2473,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2473.png",
+                        "publicationDate": "2023-10-18",
+                        "journal": "International Journal of Computer Vision",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.5192264435294609,
+                        "relevanceScore": 0.446977436542511,
+                        "publicationScore": 0.7678048780487805,
+                        "impactFactor": 11.6,
+                        "impactFactorScore": 0.48739495798319327,
+                        "citationNums": 6,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "949269914999324923_fig6_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/2473/949269914999324923/949269914999324923_fig6_1.png",
+                            "enExplain": "The image presents a comparative visualization of different methods applied to video frames. It is structured into two main rows with several columns across the top.\n\n### Top - Row Headers\nAt the top of the image, there are six columns labeled as follows:\n- **Video Frame**: This column shows the original video frames. These are the baseline images from which the subsequent analyses are derived.\n- **AttnTransit**: This refers to a method that likely uses attention - based mechanisms for processing video frames. The visualization in this column shows a heat - map overlaid on the video frame, indicating regions of interest or importance as detected by the AttnTransit method.\n- **I3D - R50**: I3D (Inflated 3D) is a well - known architecture for video analysis, and R50 likely refers to ResNet50, a popular convolutional neural network architecture. The heat - map in this column highlights the areas that the I3D - R50 model focuses on within the video frame.\n- **MotionFormer**: This is another method for video analysis, likely leveraging transformer - based architectures to capture motion information. The heat - map here shows the regions emphasized by the MotionFormer method.\n- **MViT**: MViT stands for Multiscale Vision Transformer. It is a model designed to handle video data, and the heat - map in this column represents the areas of interest as identified by MViT.\n- **GLC (Ours)**: This stands for the method proposed by the authors of this comparison. The heat - map in this column shows the regions of focus as determined by the GLC method.\n\n### Visualization Details\nEach row contains two video frames, and for each frame, there are corresponding heat - maps in the subsequent columns. The heat - maps use a color gradient (ranging from blue to red) to indicate the level of importance or attention. Blue regions represent areas with lower importance, while red regions are areas where the respective method places more emphasis.\n\n### Bottom - Row Video Frames\nThe bottom - row video frames show a different scene compared to the top - row frames. Similar to the top - row, for each of these frames, the heat - maps in the AttnTransit, I3D - R50, MotionFormer, MViT, and GLC columns represent the regions of interest detected by the respective methods.\n\nOverall, the image is used to visually compare how different video - analysis methods focus on different regions within video frames, providing insights into their performance and areas of attention. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 10,
+                        "author": [
+                          "Lingyan Wang",
+                          "Yuming Chen",
+                          "Xue Mei",
+                          "Wuyang Qin",
+                          "Xuan Qin"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Sign language video understanding requires capturing both spatial and temporal information in sign language video clips. We propose Lightweight Sign Transformer Framework, which is a two-stream lightweight network incorporating transformer architecture that consists of RGB flow and RGB difference. It leverages the latest advances in computer vision and natural language processing and applies them to video understanding. Then we implement video transformer network on sign language datasets and got excellent performance. Furthermore, we compare the performance of our network with I3D network (Carreira and Zisserman in Quo Vadis, Action recognition? A new model and the kinetics dataset. IEEE) and show better performance.",
+                        "abstractZh": "手语视频理解需要捕捉手语视频片段中的空间和时间信息。我们提出了轻量级手语Transformer框架，这是一个双流轻量级网络，它结合了由RGB流和RGB差分组成的Transformer架构。它利用了计算机视觉和自然语言处理的最新进展，并将其应用于视频理解。然后我们在手语数据集上实现了视频Transformer网络，并取得了优异的性能。此外，我们将我们网络的性能与I3D网络（Carreira和Zisserman在《何去何从，动作识别？一种新模型和动力学数据集》。IEEE）进行了比较，并展示了更好的性能。 ",
+                        "title": "Lightweight sign transformer framework",
+                        "titleZh": "轻量级符号变压器框架",
+                        "doi": "10.1007/s11760-022-02243-x",
+                        "bohriumId": "834381225740206081",
+                        "publicationId": 2733,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2733.png",
+                        "publicationDate": "2023-02-20",
+                        "journal": "Signal, Image and Video Processing",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "Sign language video understanding requires capturing both spatial and temporal information in sign language video clips. We propose Lightweight Sign Transformer Framework, which is a two-stream lightweight network incorporating transformer architecture that consists of RGB flow and RGB difference.It leverages the latest advances in computer vision and natural language processing and applies them to video understanding. Then we implement video transformer network on sign language datasets and got excellent performance.Furthermore, we compare the performance of our network with I3D network (Carreira and Zisserman in Quo Vadis, Action recognition? A new model and the kinetics dataset.IEEE) and show better performance.",
+                        "sortScore": 0.5147690589226291,
+                        "relevanceScore": 0.5631377100944519,
+                        "publicationScore": 0.6507317073170732,
+                        "impactFactor": 2,
+                        "impactFactorScore": 0.23370037670240518,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 11,
+                        "author": [
+                          "M Song",
+                          "Y Zhang",
+                          "TO Aydın"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "… Video denoising is a low-level vision task that aims to restore high quality videos from noisy \ncontent. Vision Transformer … modified ViT architecture for video processing tasks, introducing …",
+                        "abstractZh": "",
+                        "title": "TempFormer: Temporally consistent transformer for video denoising",
+                        "titleZh": "",
+                        "doi": "10.0410/cata/5351b2c49313be7c8ee268c39cc2de6d",
+                        "bohriumId": "1108427540105527297",
+                        "publicationId": 2000000,
+                        "publicationCover": "",
+                        "publicationDate": "2022-01-01",
+                        "journal": "European conference on computer vision",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.5021131427460575,
+                        "relevanceScore": 0.6095241904258728,
+                        "publicationScore": 0.4482926829268293,
+                        "impactFactor": 0,
+                        "impactFactorScore": 0.23370037670240518,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 12,
+                        "author": [
+                          "Fu-Jen Tsai",
+                          "Yan-Tsung Peng",
+                          "Chen-Yu Chang",
+                          "Chan-Yu Li",
+                          "Yen-Yu Lin",
+                          "Chung-Chi Tsai",
+                          "Chia-Wen Lin"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Video restoration is a low-level vision task that seeks to restore clean, sharp videos from quality-degraded frames. One would use the temporal information from adjacent frames to make video restoration successful. Recently, the success of the Transformer has raised awareness in the computer-vision community. However, its self-attention mechanism requires much memory, which is unsuitable for high-resolution vision tasks like video restoration. In this paper, we propose ViStripformer (Video Stripformer), which utilizes spatio-temporal strip attention to catch long-range data correlations, consisting of intra-frame strip attention (Intra-SA) and inter-frame strip attention (Inter-SA) for extracting spatial and temporal information. It decomposes video frames into strip-shaped features in horizontal and vertical directions for Intra-SA and Inter-SA to address degradation patterns with various orientations and magnitudes. Besides, ViStripformer is an effective and efficient transformer architecture with much lower memory usage than the vanilla transformer. Extensive experiments show that the proposed model achieves superior results with fast inference time on video restoration tasks, including video deblurring, demoireing, and deraining.",
+                        "abstractZh": "视频恢复是一项低级视觉任务，旨在从质量下降的帧中恢复干净、清晰的视频。人们可以使用相邻帧的时间信息来成功恢复视频。最近，Transformer 的成功提高了计算机视觉界的认识。然而，其自注意力机制需要大量内存，不适合视频恢复等高分辨率视觉任务。在本文中，我们提出了ViStripformer（Video Stripformer），它利用时空带状注意力来捕捉长距离数据相关性，包括帧内带状注意力（Intra-SA）和帧间带状注意力（Inter-SA）用于提取空间和时间信息。它将视频帧分解为 SA 内和 SA 间的水平和垂直方向的条形特征，以解决具有不同方向和幅度的退化模式。此外，ViStripformer 是一种有效且高效的变压器架构，其内存使用量比普通变压器低得多。大量实验表明，所提出的模型在视频恢复任务（包括视频去模糊、去雨和去雨）上取得了优异的结果，具有快速的推理时间。",
+                        "title": "ViStripformer: A Token-Efficient Transformer for Versatile Video Restoration",
+                        "titleZh": "ViStripformer：用于多功能视频恢复的代币高效转换器",
+                        "doi": "10.48550/arXiv.2312.14502",
+                        "bohriumId": "946108856205836721",
+                        "publicationId": 108597,
+                        "publicationCover": "https://assets.catalystplus.cn/journal_cover/arxiv.png",
+                        "publicationDate": "2023-12-22",
+                        "journal": "Computer Vision and Pattern Recognition",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.4979291405757815,
+                        "relevanceScore": 0.4854776859283447,
+                        "publicationScore": 0.7995121951219513,
+                        "impactFactor": 0,
+                        "impactFactorScore": 0.23370037670240518,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 13,
+                        "author": [
+                          "Lu Yang",
+                          "Wenhe Jia",
+                          "Shan Li",
+                          "Qing Song"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Human parsing aims to partition humans in image or video into multiple pixel-level semantic parts. In the last decade, it has gained significantly increased interest in the computer vision community and has been utilized in a broad range of practical applications, from security monitoring, to social media, to visual special effects, just to name a few. Although deep learning-based human parsing solutions have made remarkable achievements, many important concepts, existing challenges, and potential research directions are still confusing. In this survey, we comprehensively review three core sub-tasks: single human parsing, multiple human parsing, and video human parsing, by introducing their respective task settings, background concepts, relevant problems and applications, representative literature, and datasets. We also present quantitative performance comparisons of the reviewed methods on benchmark datasets. Additionally, to promote sustainable development of the community, we put forward a transformer-based human parsing framework, providing a high-performance baseline for follow-up research through universal, concise, and extensible solutions. Finally, we point out a set of under-investigated open issues in this field and suggest new directions for future study. We also provide a regularly updated project page, to continuously track recent developments in this fast-advancing field: https://github.com/soeaver/awesome-human-parsing.",
+                        "abstractZh": "人体解析旨在将图像或视频中的人体划分为多个像素级语义部分。在过去的十年中，它在计算机视觉社区中引起了显着增长的兴趣，并已被广泛应用于从安全监控到社交媒体，再到视觉特效等广泛的实际应用中。尽管基于深度学习的人体解析解决方案取得了令人瞩目的成就，但许多重要概念、现有挑战和潜在研究方向仍然令人困惑。在本次调查中，我们通过介绍各自的任务设置、背景概念、相关问题和应用、代表性文献和数据集，全面回顾了单人解析、多人解析和视频人解析三个核心子任务。我们还对基准数据集上所审查的方法进行了定量性能比较。此外，为了促进社区的可持续发展，我们提出了基于Transformer的人体解析框架，通过通用、简洁、可扩展的解决方案为后续研究提供高性能基线。最后，我们指出了该领域中一系列尚未得到充分研究的开放问题，并为未来的研究提出了新的方向。我们还提供定期更新的项目页面，以持续跟踪这个快速发展领域的最新发展：https://github.com/soeaver/awesome- human-parsing。",
+                        "title": "Deep Learning Technique for Human Parsing: A Survey and Outlook",
+                        "titleZh": "用于人体解析的深度学习技术：综述与展望",
+                        "doi": "10.1007/s11263-024-02031-9",
+                        "bohriumId": "974638656855736352",
+                        "publicationId": 2473,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2473.png",
+                        "publicationDate": "2024-03-12",
+                        "journal": "International Journal of Computer Vision",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.48796584589079917,
+                        "relevanceScore": 0.3711366057395935,
+                        "publicationScore": 0.8390243902439024,
+                        "impactFactor": 11.6,
+                        "impactFactorScore": 0.48739495798319327,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "974638656855736352_fig6_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/2473/974638656855736352/974638656855736352_fig6_1.png",
+                            "enExplain": "The diagram illustrates a computer - vision based system for human part and instance segmentation. Here is a detailed breakdown:\n\n### Input\n- On the left - hand side, there is an input image depicting one or more humans. In this case, the image shows two individuals on what appears to be an ice - skating rink. This image serves as the starting point for the system's processing.\n\n### Encoder\n- The first major component is the \"Encoder\". It takes the input image and processes it to extract features. Encoders in computer vision are typically based on convolutional neural networks (CNNs) and are designed to transform the raw pixel data of the image into a more abstract and meaningful feature representation. This feature representation is then passed on to the next stage.\n\n### Transformer Decoder\n- The \"Transformer Decoder\" is the central processing unit of this system. It takes in three types of queries:\n  - **bg queries**: These are queries related to the background. They help the model distinguish the background elements from the human - related elements in the image.\n  - **part queries**: These are used to predict individual parts of the human body. For example, limbs, heads, etc.\n  - **human queries**: These are used to identify and segment individual human instances within the image.\n\n- The Transformer Decoder processes these queries along with the feature representation from the encoder. It generates predictions for the background, human parts, and individual humans. The intermediate output shows predictions for background, human parts in different colors, and individual humans in different poses.\n\n### Outputs\n- **SHP (Single - Human Parsing)**: This output provides a segmentation of a single human. It combines the part predictions and groups them in a way that represents the parts of a single human entity. The example SHP output shows a single human with its parts colored differently for clear identification.\n- **grouping**: This is a process that takes the individual part and human predictions and groups them appropriately. It is crucial for separating different human instances and their associated parts.\n- **MHP (Multi - Human Parsing) / VHP (Video - Human Parsing)**: These outputs are for multi - human segmentation. MHP is for still images with multiple humans, and VHP is likely an extension for video sequences where multiple humans need to be segmented over time. The MHP / VHP output example shows multiple humans, each with their parts colored differently to distinguish between different individuals and their body parts.\n\nOverall, this system uses an encoder - decoder architecture with a Transformer - based decoder to perform human part and instance segmentation, which has applications in various fields such as action recognition, human - computer interaction, and surveillance. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 14,
+                        "author": [
+                          "Yimin Jiang",
+                          "Tingfei Yan",
+                          "Mingze Yao",
+                          "Huibing Wang",
+                          "Wenzhe Liu"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Visual question answering (VQA) has become a hot study topic with challenging motivation of correctly answering the videos or images questions in recent years. However, the existing VQA model mostly aimed at answering questions about images and performed poorly in the video question answering (VideoQA) domain. VideoQA needs to simultaneously consider the correlations between video frames and the dynamic information of multiple objects in video. Therefore, we propose a novel Cascade Transformers with Dynamic Attention for Video Question Answering (CTDA-QA), which aims to simultaneously solve the above considerations. Specifically, the proposed CTDA-QA model utilizes multiple transformers structure to encode videos for reasoning complex spatial and temporal information, which is different from the previous recurrent neural network methods. Besides, in order to effectively capture the dynamic information from various scenarios in videos, a flexible attention module has been proposed to explore the essential relations between objects in a dynamic timeline. Finally, to avoid spurious answers and fully explore the cross-modal relationships, a mixed-supervised learning strategy is designed for optimizing the reasoning tasks. The experiments on several benchmark video question–answer datasets clearly verify the performance and effectiveness of CTDA-QA, which contains the results in contrast to the state-of-the-art methods. Besides, the provided ablation study and visualization results further reveal the potential of CTDA-QA.",
+                        "abstractZh": "视觉问答（VQA）近年来已成为一个热门的研究课题，其具有挑战性的动机是正确回答视频或图像问题。然而，现有的VQA模型大多旨在回答关于图像的问题，在视频问答（VideoQA）领域表现不佳。VideoQA需要同时考虑视频帧之间的相关性以及视频中多个对象的动态信息。因此，我们提出了一种用于视频问答的具有动态注意力的新型级联变换器（CTDA-QA），旨在同时解决上述问题。具体而言，所提出的CTDA-QA模型利用多个变换器结构对视频进行编码，以推理复杂的空间和时间信息，这与以前的递归神经网络方法不同。此外，为了有效地从视频中的各种场景中捕捉动态信息，提出了一种灵活的注意力模块，以探索动态时间线中对象之间的本质关系。最后，为了避免虚假答案并充分探索跨模态关系，设计了一种混合监督学习策略来优化推理任务。在几个基准视频问答数据集上的实验清楚地验证了CTDA-QA的性能和有效性，其中包含与最先进方法对比的结果。此外，所提供的消融研究和可视化结果进一步揭示了CTDA-QA的潜力。 ",
+                        "title": "Cascade transformers with dynamic attention for video question answering",
+                        "titleZh": "用于视频问答的具有动态注意力机制的级联变压器",
+                        "doi": "10.1016/j.cviu.2024.103983",
+                        "bohriumId": "975936320868188169",
+                        "publicationId": 2613,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2613.png",
+                        "publicationDate": "2024-03-16",
+                        "journal": "Computer Vision and Image Understanding",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.48327054764625055,
+                        "relevanceScore": 0.4649015963077545,
+                        "publicationScore": 0.8409756097560975,
+                        "impactFactor": 4.3,
+                        "impactFactorScore": 0.18067226890756302,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "975936320868188169_fig2_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/2613/975936320868188169/975936320868188169_fig2_1.png",
+                            "enExplain": "### Overall Architecture Overview\nThe image depicts a sophisticated architecture designed for processing video - related tasks, likely involving video understanding and answering questions about the video content. The architecture is divided into two main sections: the video data processing pipeline at the top and the question - answering pipeline at the bottom.\n\n### Video Data Processing\n1. **Input Video Data**:\nAt the far - left, there is a stack of video frames labeled \"Video data\". These frames represent a sequence of visual information from a video, which serves as the initial input to the system.\n2. **Cascade Transformers**:\nNext to the video data, the \"Cascade Transformers\" block is shown. This block is composed of multiple interconnected transformers. Transformers are neural network architectures well - suited for handling sequential data. In this context, they are likely used to extract high - level features from the video frames. The connections within the Cascade Transformers are indicated by lines, showing how information flows between different parts of the transformers.\n3. **Graph Convolutional Network (GCN)**:\nFollowing the Cascade Transformers, there is a GCN block. The GCN takes the features from the Cascade Transformers and processes them further. It likely models the relationships between different elements (e.g., objects) in the video frames as a graph, where nodes and edges are processed to capture structural information.\n4. **Object - level and Video - level Transformers**:\nAfter the GCN, there are two types of transformers: \"Object - level Transformer\" and \"Video - level Transformer\". The Object - level Transformer focuses on individual objects within the video frames, while the Video - level Transformer looks at the overall video context. The arrows and connections indicate how features are passed between these transformers at different levels (object - level, frame - level, and group - level).\n5. **Dynamic Attention**:\nThe \"Dynamic Attention\" block is then applied. This block is designed to selectively focus on different parts of the video features. It operates at multiple levels (object - level, frame - level, and group - level) to capture the most relevant information for the task at hand.\n\n### Question - Answering Pipeline\n1. **Question Data**:\nOn the left - hand side of the lower section, there is a block labeled \"Question data\". This contains questions related to the video content, such as \"Question: what did the ball hit?\" and \"Question: what type of event is occurring?\".\n2. **Language Model**:\nThe questions are fed into a \"Language Model\". This model processes the textual information in the questions to extract semantic features.\n3. **Mixed - supervised Loss**:\nThe output of the language model is combined with other features in the system, and a \"Mixed - supervised Loss\" ($L_{mix}$) is calculated. This loss function is likely used to train the overall system by comparing the predicted answers with the ground - truth answers.\n4. **Textual Feature and Dynamic Attention in Answer Generation**:\nThe textual features from the language model are then processed further. A \"Textual Feature\" block is shown, and another \"Dynamic Attention\" mechanism is applied here. This attention mechanism helps in focusing on the most relevant textual and video features for generating the correct answers.\n5. **Output and Answer**:\nFinally, the processed features go through a sigmoid and softmax function in the \"Output\" block. The output of this block is the \"Answer\", which is the system's response to the input questions based on the analysis of the video and question data.\n\nIn summary, this architecture combines visual feature extraction from video frames using transformers and GCNs with natural language processing of questions to generate accurate answers about the video content. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 15,
+                        "author": [
+                          "Xiao Ke",
+                          "Xin Miao",
+                          "Wenzhong Guo"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Action segmentation is a research hotspot in human action analysis, which aims to split videos into segments of different actions. Recent algorithms have achieved great success in modeling based on temporal convolution, but these methods weight local or global timing information through additional modules, ignoring the existing long-term and short-term information connections between actions. This paper proposes a U-Transformer structure based on multi-level refinement, introduces neighborhood attention to learn the neighborhood information of adjacent frames, and aggregates video frame features to effectively process long-term sequence information. Then a loss optimization strategy is proposed to smooth the original classification effect and generate a more accurate calibration sequence by introducing a pairing similarity optimization method based on deep feature learning. In addition, we propose a timestamp supervised training method to generate complete information for actions based on pseudo-label predictions for action boundary predictions. Experiments on three challenging action segmentation datasets, 50Salads, GTEA, and Breakfast, show that our model performs state-of-the-art models, and our weakly supervised model also performs comparably to fully supervised performance.",
+                        "abstractZh": "动作分割是人类动作分析中的一个研究热点，其目的是将视频分割成不同动作的片段。最近的算法在基于时间卷积的建模方面取得了巨大成功，但这些方法通过额外的模块对局部或全局时间信息进行加权，忽略了动作之间现有的长期和短期信息连接。本文提出了一种基于多级细化的U-Transformer结构，引入邻域注意力来学习相邻帧的邻域信息，并聚合视频帧特征以有效处理长期序列信息。然后提出了一种损失优化策略，通过引入基于深度特征学习的配对相似性优化方法来平滑原始分类效果并生成更准确的校准序列。此外，我们提出了一种时间戳监督训练方法，基于动作边界预测的伪标签预测为动作生成完整信息。在三个具有挑战性的动作分割数据集50Salads、GTEA和Breakfast上的实验表明，我们的模型性能优于现有模型，并且我们的弱监督模型的性能也与完全监督的性能相当。 ",
+                        "title": "U-Transformer-based multi-levels refinement for weakly supervised action segmentation",
+                        "titleZh": "基于U型变压器的弱监督动作分割多级细化",
+                        "doi": "10.1016/j.patcog.2023.110199",
+                        "bohriumId": "947347274646683684",
+                        "publicationId": 2432,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2432.png",
+                        "publicationDate": "2023-12-28",
+                        "journal": "Pattern Recognition",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.47758781648227777,
+                        "relevanceScore": 0.4234579801559448,
+                        "publicationScore": 0.802439024390244,
+                        "impactFactor": 7.5,
+                        "impactFactorScore": 0.31512605042016806,
+                        "citationNums": 1,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "947347274646683684_fig2_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/2432/947347274646683684/947347274646683684_fig2_1.png",
+                            "enExplain": "The image depicts the architecture of a U - Transformer, a neural network design, likely for video - related tasks.\n\n### Overall Structure\nThe diagram is divided into three main sections: the Encoder, the U - Transformer Architecture in the middle, and the Decoder.\n\n### Encoder\nThe encoder section is on the left - hand side of the diagram. It consists of several processing steps.\n- **Instance Norm**: This is a normalization technique applied to the input data. Instance normalization normalizes the input features for each instance in a mini - batch independently, which helps in stabilizing the training process.\n- **Self - Attention**: This mechanism allows the model to weigh the importance of different parts of the input when computing a representation. It enables the model to focus on relevant features within a single input sequence.\n- **Repeating Layers**: After self - attention, there are again instance normalization, ReLU (Rectified Linear Unit) activation function, and a Feed - Forward Network (FFN). The ReLU function introduces non - linearity, and the FFN further processes the features. Finally, there is a downsampling operation, which reduces the spatial or temporal resolution of the input features.\n\n### U - Transformer Architecture\nThis is the central part of the diagram, highlighted in blue. It consists of encoder blocks and decoder blocks that share weights. The encoder blocks process the input further, and the decoder blocks are responsible for reconstructing or generating the output. The sharing of weights between encoder and decoder blocks helps in parameter efficiency and can lead to better generalization.\n\n### Decoder\nThe decoder is on the right - hand side of the diagram. It starts with an upsampling operation, which increases the spatial or temporal resolution of the features. Then, there are similar components as in the encoder, such as FFN, ReLU, instance normalization, and attention. The attention mechanism in the decoder helps in generating the output by focusing on relevant parts of the input features.\n\n### Attention Mechanism\nThe attention mechanism is detailed in the middle - bottom part of the diagram. It takes an input and splits it into three components: Query (Q), Key (K), and Value (V). These components are used to compute the attention weights. The \"Top - k\" operation selects the top k most relevant elements based on the attention scores. The output is then computed as a weighted sum of the values.\n\n### Input and Output Examples\nAt the bottom - left corner of the diagram, there are examples of input video frames. These input video frames are processed through the encoder, U - Transformer, and decoder to generate an output, although the specific nature of the output is not detailed in this diagram. The overall architecture is designed to handle video data, likely for tasks such as video segmentation, video generation, or other video - related computer vision tasks. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 16,
+                        "author": [
+                          "Qiaoyun Zhang",
+                          "Chih-Yung Chang",
+                          "Ming-Yang Su",
+                          "Hsiang-Chuan Chang",
+                          "Diptendu Sinha Roy"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "With the increasing popularity of watching baseball videos, there is a growing desire among fans to enjoy the highlights of these videos. However, the extraction of the highlights from lengthy baseball videos faces a significant challenge due to its time-consuming and labor-intensive nature. To address this challenge, this paper proposes a novel mechanism, called Hierarchical Multimodal Transformer for Video query (HMTV). The proposed HMTV incorporates a two-phase involving Coarse-Grained clipping for candidate videos and Fine-Grained identification for highlights. In the Coarse-Grained phase, a pitching detection model is employed to extract relevant candidate videos from baseball videos, encompassing the features of pitch deliveries and pitching. In the Fine-Grained phase, Transformer encoder and pre-trained Bidirectional Encoder Representations from Transformers (BERT) are utilized to capture relationship features between frames of candidate videos and words from users' questions, respectively. These relationship features are then fed into the Video Query (VideoQ) model, implemented by the Text Video Attention (TVA). The VideoQ model identifies the start and end positions of the highlights mentioned in the query within the candidate videos. Simulation results demonstrate that the proposed HMTV significantly improves accuracy of highlights identification in terms of precision, recall, and F1-score.",
+                        "abstractZh": "随着观看棒球视频的日益普及，球迷们越来越渴望欣赏这些视频的精彩片段。然而，从冗长的棒球视频中提取精彩片段面临着巨大挑战，因为这既耗时又费力。为应对这一挑战，本文提出了一种名为用于视频查询的分层多模态Transformer（HMTV）的新颖机制。所提出的HMTV包含一个两阶段过程，即用于候选视频的粗粒度剪辑和用于精彩片段的细粒度识别。在粗粒度阶段，使用投球检测模型从棒球视频中提取相关候选视频，这些视频包含投球动作和投球的特征。在细粒度阶段，分别利用Transformer编码器和预训练的来自Transformer的双向编码器表示（BERT）来捕捉候选视频帧与用户问题中的单词之间的关系特征。然后将这些关系特征输入到由文本视频注意力（TVA）实现的视频查询（VideoQ）模型中。VideoQ模型在候选视频中识别查询中提到的精彩片段的起始和结束位置。仿真结果表明，所提出的HMTV在精确率、召回率和F1分数方面显著提高了精彩片段识别的准确性。 ",
+                        "title": "HMTV: hierarchical multimodal transformer for video highlight query on baseball",
+                        "titleZh": "HMTV：用于棒球视频精彩片段查询的分层多模态变换器",
+                        "doi": "10.1007/s00530-024-01479-6",
+                        "bohriumId": "1045910865003413506",
+                        "publicationId": 2812,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2812.png",
+                        "publicationDate": "2024-09-25",
+                        "journal": "Multimedia Systems",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "To address these problems, other researchers [37,38,39,40,41,42,43] have adopted Transformer models for various video analysis and summarization tasks, as Transformer models have significantly influenced the field of video processing. Dosovitskiy et al.[37] introduced the Vision Transformer (ViT), a pioneering model that adapts the Transformer architecture, originally designed for natural language processing, for image processing tasks.The ViT distinguished itself thanks to numerous groundbreaking features. The ViT leveraged the Transformer architecture’s self-attention mechanism, which enabled ViT to aggregate information from different patches based on their relevance to each other, considering the global context of the entire image.To further consider the spatial–temporal correlations between frames, Ahn et al.[38] utilized a spatial–temporal cross attention Transformer for human action recognition.Hsu et al.[39] and Zhao et al.[40] proposed a spatial–temporal video Transformer, which learned the spatial and temporal correlations from the full set of video summaries to achieve state-of-the-art performance. However, these models might perform poorly in handling long videos and highly dynamic scenes due to their reliance on strong correlations between consecutive frames.",
+                        "sortScore": 0.4768250375690237,
+                        "relevanceScore": 0.43398144841194153,
+                        "publicationScore": 0.9351219512195122,
+                        "impactFactor": 3.5,
+                        "impactFactorScore": 0.14705882352941177,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 17,
+                        "author": [
+                          "Hao Zhang",
+                          "Yanbin Hao",
+                          "Chong-Wah Ngo"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Transformer achieves remarkable successes in understanding 1 and 2-dimensional signals (e.g., NLP and Image Content Understanding). As a potential alternative to convolutional neural networks, it shares merits of strong interpretability, high discriminative power on hyper-scale data, and flexibility in processing varying length inputs. However, its encoders naturally contain computational intensive operations such as pair-wise self-attention, incurring heavy computational burden when being applied on the complex 3-dimensional video signals. This paper presents Token Shift Module (i.e., TokShift), a novel, zero-parameter, zero-FLOPs operator, for modeling temporal relations within each transformer encoder. Specifically, the TokShift barely temporally shifts partial [Class] token features back-and-forth across adjacent frames. Then, we densely plug the module into each encoder of a plain 2D vision transformer for learning 3D video representation. It is worth noticing that our TokShift transformer is a pure convolutional-free video transformer pilot with computational efficiency for video understanding. Experiments on standard benchmarks verify its robustness, effectiveness, and efficiency. Particularly, with input clips of 8/12 frames, the TokShift transformer achieves SOTA precision: 79.83%/80.40% on the Kinetics-400, 66.56% on EGTEA-Gaze+, and 96.80% on UCF-101 datasets, comparable or better than existing SOTA convolutional counterparts. Our code is open-sourced in: https://github.com/VideoNetworks/TokShift-Transformer.",
+                        "abstractZh": "Transformer 在理解一维和二维信号（例如 NLP 和图像内容理解）方面取得了显着的成功。作为卷积神经网络的潜在替代品，它具有可解释性强、对超大规模数据具有高判别力以及处理不同长度输入的灵活性等优点。然而，其编码器自然包含计算密集型操作，例如成对自注意力，在应用于复杂的 3 维视频信号时会产生沉重的计算负担。本文提出了令牌移位模块（即 TokShift），这是一种新颖的零参数、零 FLOP 运算符，用于对每个变压器编码器内的时间关系进行建模。具体来说，TokShift 几乎不会临时在相邻帧之间来回移动部分​​ [Class] 标记特征。然后，我们将该模块密集地插入到普通 2D 视觉转换器的每个编码器中，以学习 3D 视频表示。值得注意的是，我们的 TokShift 转换器是一个纯粹的无卷积视频转换器试点，具有视频理解的计算效率。标准基准测试验证了其稳健性、有效性和效率。特别是，对于 8/12 帧的输入剪辑，TokShift 转换器实现了 SOTA 精度：在 Kinetics-400 上为 79.83%/80.40%，在 EGTEA-Gaze 上为 66.56%，在 UCF-101 数据集上为 96.80%，与现有数据集相当或更好SOTA 卷积对应物。我们的代码是开源的：https://github.com/VideoNetworks/TokShift-Transformer。",
+                        "title": "Token Shift Transformer for Video Classification",
+                        "titleZh": "用于视频分类的令牌移位转换器",
+                        "doi": "10.48550/arXiv.2108.02432",
+                        "bohriumId": "867768503204053482",
+                        "publicationId": 108597,
+                        "publicationCover": "https://assets.catalystplus.cn/journal_cover/arxiv.png",
+                        "publicationDate": "2021-08-05",
+                        "journal": "Computer Vision and Pattern Recognition",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.45916795713489417,
+                        "relevanceScore": 0.562176525592804,
+                        "publicationScore": 0.375609756097561,
+                        "impactFactor": 0,
+                        "impactFactorScore": 0.23370037670240518,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 18,
+                        "author": [
+                          "Nazia Aslam",
+                          "Maheshkumar H. Kolekar"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Video anomaly detection aims to identify a set of abnormal events in videos. Deep reconstruction and prediction-based models have been employed to detect anomalies. Deep reconstruction models sometimes recreate the abnormal events along with the normal ones. However, the prediction-based approaches have demonstrated encouraging results. This paper presents a video vision transformer (ViViT) based generative adversarial network (GAN), TransGANomaly, a novel approach for detecting anomalies. The proposed framework is a video frame predictor and trained only on normal video data adversarially. The generator of the GAN is a ViViT network that receives 3D input tokens from the video snippets. The generator aims to predict the future frame based on past sequences. After that, the predicted and original frames are given to the model’s discriminator for binary classification. Extensive experiments have been performed on UCSD Pedestrian, CUHK Avenue, and ShanghiaTech datasets to validate the efficacy of the proposed method.",
+                        "abstractZh": "视频异常检测旨在识别视频中的一组异常事件。基于深度重建和预测的模型已被用于检测异常。深度重建模型有时会在重建正常事件的同时也重建异常事件。然而，基于预测的方法已取得了令人鼓舞的成果。本文提出了一种基于视频视觉Transformer（ViViT）的生成对抗网络（GAN），即TransGANomaly，这是一种用于检测异常的新颖方法。所提出的框架是一个视频帧预测器，并且仅在正常视频数据上进行对抗训练。GAN的生成器是一个ViViT网络，它从视频片段中接收3D输入令牌。生成器旨在根据过去的序列预测未来的帧。之后，将预测帧和原始帧提供给模型的判别器进行二分类。已在UCSD Pedestrian、CUHK Avenue和ShanghiaTech数据集上进行了大量实验，以验证所提方法的有效性。 ",
+                        "title": "TransGANomaly: Transformer based Generative Adversarial Network for Video Anomaly Detection",
+                        "titleZh": "TransGANomaly：用于视频异常检测的基于Transformer的生成对抗网络",
+                        "doi": "10.1016/j.jvcir.2024.104108",
+                        "bohriumId": "985479517327852170",
+                        "publicationId": 2631,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2631.png",
+                        "publicationDate": "2024-04-01",
+                        "journal": "Journal of Visual Communication and Image Representation",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.4571867443860832,
+                        "relevanceScore": 0.44263648986816406,
+                        "publicationScore": 0.848780487804878,
+                        "impactFactor": 2.6,
+                        "impactFactorScore": 0.1092436974789916,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "985479517327852170_fig2_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/2631/985479517327852170/985479517327852170_fig2_1.png",
+                            "enExplain": "This image depicts a diagram of a generative - adversarial network (GAN) architecture specifically designed for video - related tasks. The overall system is divided into two main components: the Generator and the Discriminator.\n\n### Generator\nThe Generator takes an input sequence \\(X_t=\\{I_{t - \\tau},\\cdots,I_t\\}\\), which is a set of previous video frames. This input sequence is first processed by a 3D convolutional layer (Conv3D). The purpose of the 3D convolutional layer is to extract spatial - temporal features from the input video frames.\n\nAfter the Conv3D layer, the output is split into multiple 2D tokens. These tokens are then flattened and linearly projected. This step is followed by two types of embeddings: position embedding and token embedding. Position embedding helps the model understand the spatial - temporal position of the tokens, while token embedding represents the semantic information of the tokens.\n\nThe processed tokens are then fed into a Video Vision Transformer. The Video Vision Transformer is a key component that processes the tokens to generate a high - level representation of the video sequence. After the Video Vision Transformer, a transposed 2D convolutional layer (Conv2D Transpose) is used to upsample the feature map and generate the output frame \\(\\hat{I}_{t + 1}\\).\n\n### Loss Calculation\nThe generated frame \\(\\hat{I}_{t + 1}\\) is compared with the ground - truth frame \\(I_{t+1}\\) using two types of losses: intensity loss and gradient loss. The intensity loss measures the pixel - level difference between the generated and the real frame, while the gradient loss evaluates the difference in the gradients of the frames. This helps in generating more realistic frames by ensuring both pixel - level and structural similarity.\n\n### Discriminator\nThe Discriminator is a neural network that takes as input either the generated frame \\(\\hat{I}_{t + 1}\\) or the real frame \\(I_{t+1}\\). It consists of multiple layers including batch normalization, activation functions, and a final sigmoid layer. The Discriminator's goal is to classify whether the input frame is real or fake. It outputs a binary decision: \"Real\" or \"Fake\".\n\n### Additional Elements in the Diagram\n- **Arrows**: The arrows represent the data flow in the network. For example, the arrow from the input sequence to the Conv3D layer shows the direction of data movement during the processing in the Generator.\n- **Symbols**: The symbols such as the addition symbol represent operations like element - wise addition. The batch normalization, activation, and sigmoid operations are also clearly marked with their respective symbols to indicate the type of processing happening in each layer of the Discriminator.\n\nOverall, this architecture aims to generate realistic video frames using a combination of convolutional and transformational operations in the Generator and to distinguish between real and generated frames using the Discriminator, with the losses guiding the training process to improve the quality of the generated video frames. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 19,
+                        "author": [
+                          "Xing Wu",
+                          "Chenjie Tao",
+                          "Jian Zhang",
+                          "Qun Sun",
+                          "Jianjia Wang",
+                          "Weimin Li",
+                          "Yue Liu",
+                          "Yike Guo"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Spatial and temporal attention plays an important role in video classification tasks. However, there are few studies about the mechanism of spatial and temporal attention behind classification problems. Transformer owns excellent capabilities at training scalability and capturing long-range dependencies among sequences because of its self-attention mechanism, which has achieved great success in many fields, especially in video classifications. The spatio-temporal attention is separated into a temporal attention module and a spatial attention module through Divided-Space-Time Attention, which makes it more conveniently to configure the attention module and adjust the way of attention interaction. Then single-stream models and two-stream models are designed to study the laws of information interaction between spatial attention and temporal attention with a lot of carefully designed experiments. Experiments show that the spatial attention is more critical than the temporal attention, thus the balanced strategy that is commonly used is not always the best choice. Furthermore, there is a necessity to consider the classical two-stream structure models in some cases, which can get better results than the popular single-stream structure models.",
+                        "abstractZh": "空间和时间注意力在视频分类任务中起着重要作用。然而，关于分类问题背后的时空注意力机制的研究却很少。 Transformer凭借其自注意力机制，在训练可扩展性和捕获序列之间的长程依赖性方面拥有出色的能力，在许多领域，特别是在视频分类方面取得了巨大的成功。通过Divided-Space-Time Attention将时空注意力分为时间注意力模块和空间注意力模块，使得更方便地配置注意力模块和调整注意力交互方式。然后设计单流模型和双流模型，通过大量精心设计的实验来研究空间注意力和时间注意力之间的信息交互规律。实验表明，空间注意力比时间注意力更重要，因此常用的平衡策略并不总是最佳选择。此外，在某些情况下有必要考虑经典的双流结构模型，这样可以获得比流行的单流结构模型更好的结果。",
+                        "title": "Space or time for video classification transformers",
+                        "titleZh": "用于视频分类Transformer的空间或时间维度",
+                        "doi": "10.1007/s10489-023-04756-5",
+                        "bohriumId": "883923090835243332",
+                        "publicationId": 2510,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2510.png",
+                        "publicationDate": "2023-07-07",
+                        "journal": "Applied Intelligence",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "In recent years, deep learning technology has made significant progress in processing medial data like image [1, 2] and video [3, 4]. Among these media data, video is the most difficult to process.Due to the high-dimensional and temporal nature of video data, traditional computer vision methods often struggle with this task. Transformer [5] owns excellent performance in processing sequence data, it is widely used in video classification [6,7,8].In the video classification task, the Transformer model can regard the video frame sequence as a set of sequence data, each frame as an element in the sequence, and use the self-attention mechanism to encode each frame. This method can not only handle variable-length sequences, but also learn long-term dependencies in sequences, thereby improving the accuracy of video classification.",
+                        "sortScore": 0.4524826976490118,
+                        "relevanceScore": 0.46733176708221436,
+                        "publicationScore": 0.7175609756097561,
+                        "impactFactor": 3.4,
+                        "impactFactorScore": 0.14285714285714285,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 20,
+                        "author": [
+                          "Andong Deng",
+                          "Taojiannan Yang",
+                          "Chen Chen",
+                          "Qian Chen",
+                          "Leslie Neely",
+                          "Sakiko Oyama"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Correctly recognizing the behaviors of children with Autism Spectrum Disorder (ASD) is of vital importance for the diagnosis of Autism and timely early intervention. However, the observation and recording during the treatment from the parents of autistic children may not be accurate and objective. In such cases, automatic recognition systems based on computer vision and machine learning (in particular deep learning) technology can alleviate this issue to a large extent. Existing human action recognition models can now achieve impressive performance on challenging activity datasets, e.g., daily activity, and sports activity. However, problem behaviors in children with ASD are very different from these general activities, and recognizing these problem behaviors via computer vision is less studied. In this paper, we first evaluate a strong baseline for action recognition, i.e., Video Swin Transformer, on two autism behaviors datasets (SSBD and ESBD) and show that it can achieve high accuracy and outperform the previous methods by a large margin, demonstrating the feasibility of vision-based problem behaviors recognition. Moreover, we propose language-assisted training to further enhance the action recognition performance. Specifically, we develop a two-branch multimodal deep learning framework by incorporating the ”freely available” language description for each type of problem behavior. Experimental results demonstrate that incorporating additional language supervision can bring an obvious performance boost for the autism problem behaviors recognition task as compared to using the video information only (i.e., 3.49% improvement on ESBD and 1.46% on SSBD). Our code and model will be publicly available for reproducing the results.",
+                        "abstractZh": "正确识别自闭症谱系障碍（ASD）儿童的行为对于自闭症的诊断和及时的早期干预至关重要。然而，自闭症儿童家长在治疗过程中的观察和记录可能并不准确和客观。在这种情况下，基于计算机视觉和机器学习（特别是深度学习）技术的自动识别系统可以在很大程度上缓解这一问题。现有的人类动作识别模型现在在具有挑战性的活动数据集上，例如日常活动和体育活动，能够取得令人印象深刻的性能。然而，ASD儿童的问题行为与这些一般活动有很大不同，通过计算机视觉识别这些问题行为的研究较少。在本文中，我们首先在两个自闭症行为数据集（SSBD和ESBD）上评估了一个强大的动作识别基线，即视频Swin Transformer，并表明它可以实现高精度，并且比以前的方法有很大优势，证明了基于视觉的问题行为识别的可行性。此外，我们提出了语言辅助训练以进一步提高动作识别性能。具体来说，我们通过纳入每种问题行为的“免费可用”语言描述，开发了一个双分支多模态深度学习框架。实验结果表明，与仅使用视频信息相比，纳入额外的语言监督可以为自闭症问题行为识别任务带来明显的性能提升（即ESBD上提高3.49%，SSBD上提高1.46%）。我们的代码和模型将公开可用，以重现结果。 ",
+                        "title": "Language-assisted deep learning for autistic behaviors recognition",
+                        "titleZh": "用于自闭症行为识别的语言辅助深度学习",
+                        "doi": "10.1016/j.smhl.2023.100444",
+                        "bohriumId": "954385910898622822",
+                        "publicationId": 50214,
+                        "publicationCover": "https://ars.els-cdn.com/content/image/X23526483.jpg",
+                        "publicationDate": "2023-12-01",
+                        "journal": "Smart Health",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.4402753039462288,
+                        "relevanceScore": 0.3928025960922241,
+                        "publicationScore": 0.7892682926829269,
+                        "impactFactor": 0,
+                        "impactFactorScore": 0.23370037670240518,
+                        "citationNums": 1,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "954385910898622822_fig3_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/50214/954385910898622822/954385910898622822_fig3_1.png",
+                            "enExplain": "The image depicts the architecture of the \"Video Swin Transformer.\" Here is a detailed explanation in English using Markdown format:\n\n### Overall Structure\nThe diagram illustrates a sequential pipeline for processing video data using the Video Swin Transformer. It consists of multiple stages, each performing specific operations on the input video - related data.\n\n### Components and Their Functions\n\n1. **Patch Merging**:\n   - The first step in each stage is \"Patch Merging.\" This operation combines adjacent patches in the feature map. For example, in image processing, patches are small regions of an image. In the context of video, these patches are likely small 3 - D regions (spatial - temporal) of the video frames. The purpose of patch merging is to downsample the feature representation while aggregating local information.\n\n2. **Linear Embedding**:\n   - Following patch merging, \"Linear Embedding\" is applied. This is a linear transformation that projects the merged patch features into a new feature space. It is used to convert the raw patch features into a more suitable representation for further processing in the Transformer architecture.\n\n3. **Transformer Block**:\n   - The core component of each stage is the \"Transformer Block.\" This block contains self - attention mechanisms and feed - forward neural networks. The self - attention mechanism allows the model to weigh the importance of different parts of the input feature map when computing the output. The feed - forward network further processes the output of the self - attention layer to learn more complex feature representations.\n\n4. **Patch Size Multipliers (`x2`, `x6` etc.)**:\n   - Next to each Transformer Block, there are multipliers (`x2`, `x6`, etc.). These multipliers indicate the number of times the Transformer Block is repeated in that particular stage. For example, in the second stage, the Transformer Block is repeated twice (`x2`), and in the third stage, it is repeated six times (`x6`). Repeating the Transformer Block multiple times allows the model to learn more complex and hierarchical feature representations.\n\n### Stages and Progression\nThe diagram shows four main stages in the Video Swin Transformer pipeline. Each stage builds on the output of the previous one, gradually downsampling the feature map (through patch merging) and increasing the complexity of the learned feature representations (through repeated Transformer Blocks).\n\nIn summary, the Video Swin Transformer architecture processes video data by first merging patches, embedding them linearly, and then repeatedly applying Transformer Blocks in multiple stages to learn hierarchical and complex spatio - temporal feature representations for video understanding tasks. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 21,
+                        "author": [
+                          "Muhammad Ahmad Amin",
+                          "Yongjian Hu",
+                          "Chang-Tsun Li",
+                          "Beibei Liu"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Deepfake videos present a significant challenge in the current media landscape. While current deepfake detection methods demonstrate satisfactory performance, there is still room for improvement in their ability to generalize and detect unseen scenarios, particularly those involving imperceptible cues. This paper introduces a novel multi-modal deepfake detection model named SpectraVisionFusion Transformer (SVFT), which incorporates spatial and frequency domain statistical artifacts to improve generalization performance. The SVFT framework uses two different backbone encoder models to take advantage of both spatial and frequency domain cues in video sequences, along with a decoder and classifier, for common cross-attention and classification, respectively. The spatial domain branch uses a convolutional transformer-based encoder to analyze facial visual features. In contrast, the frequency domain branch employs a language transformer encoder. Additionally, we introduce a weighted feature embedding fusion mechanism that integrates spectral-based statistical feature embeddings and visual cues to achieve a more comprehensive and balanced spatial-frequency feature representation. By coordinately analyzing these modalities, our model exhibits improved detection and generalization capabilities in unseen scenarios. Our proposed SVFT model achieved 92.57% and 80.63% accuracy in extensive cross-manipulation and dataset evaluation, respectively, while surpassing the performance of traditional and single-domain-based approaches.",
+                        "abstractZh": "深度伪造视频在当前媒体环境中构成了重大挑战。虽然当前的深度伪造检测方法表现出令人满意的性能，但在泛化能力以及检测未见场景（特别是那些涉及难以察觉线索的场景）方面仍有改进空间。本文介绍了一种名为光谱视觉融合Transformer（SVFT）的新型多模态深度伪造检测模型，该模型结合了空间和频域统计特征，以提高泛化性能。SVFT框架使用两种不同的主干编码器模型，分别利用视频序列中的空间和频域线索，同时还配备了解码器和分类器，分别用于常见的交叉注意力计算和分类。空间域分支使用基于卷积Transformer的编码器来分析面部视觉特征。相比之下，频域分支采用语言Transformer编码器。此外，我们引入了一种加权特征嵌入融合机制，该机制整合了基于光谱的统计特征嵌入和视觉线索，以实现更全面、平衡的空间 - 频率特征表示。通过协同分析这些模态，我们的模型在未见场景中展现出了改进的检测和泛化能力。我们提出的SVFT模型在广泛的交叉操作和数据集评估中分别达到了92.57%和80.63%的准确率，同时超越了传统方法和基于单域的方法的性能。 ",
+                        "title": "Deepfake detection based on cross-domain local characteristic analysis with multi-domain transformer",
+                        "titleZh": "基于多域变压器的跨域局部特征分析的深度伪造检测",
+                        "doi": "10.1016/j.aej.2024.02.035",
+                        "bohriumId": "970138966319693828",
+                        "publicationId": 108269,
+                        "publicationCover": "",
+                        "publicationDate": "2024-02-29",
+                        "journal": "AEJ - Alexandria Engineering Journal",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.4344176534828962,
+                        "relevanceScore": 0.36840569972991943,
+                        "publicationScore": 0.833170731707317,
+                        "impactFactor": 0,
+                        "impactFactorScore": 0.23370037670240518,
+                        "citationNums": 1,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "970138966319693828_fig5_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/108269/970138966319693828/970138966319693828_fig5_1.png",
+                            "enExplain": "The provided image illustrates a detailed architecture diagram for a video - processing neural network, likely designed for tasks such as video classification. The diagram is divided into two main parts: (a) the overall pipeline for processing video frames, and (b) the internal structure of a Transformer block.\n\n### (a) Overall Pipeline for Processing Video Frames\n1. **Input Video Frame ($x_t$)**:\n   - The starting point is an input video frame, represented as a grid - like structure. This frame serves as the raw data that will be processed through the network.\n2. **Stage 1**:\n   - **Convolutional Token Embedding**:\n     - The first operation in this stage is convolutional token embedding. It takes the input video frame and divides it into smaller patches (represented as green - shaded squares). These patches are then converted into tokens through convolutional operations. Convolutional operations are used to extract local features from the frame, and the tokenization process is crucial for representing the frame in a format suitable for further processing.\n   - **Convolutional Transformer Block**:\n     - After token embedding, the tokens pass through $N_1$ convolutional Transformer blocks. These blocks combine the power of convolutional and Transformer architectures. Convolutional layers in these blocks further process the local features, while the Transformer part (which includes self - attention mechanisms) helps in capturing long - range dependencies between the tokens.\n3. **Stage 2**:\n   - Similar to Stage 1, it starts with Convolutional Token Embedding, which again processes the output from the previous stage. This is followed by $N_2$ Convolutional Transformer Blocks. The purpose of these operations in Stage 2 is to further refine the feature representation by extracting more complex local and global features.\n4. **Stage 3**:\n   - Once again, Convolutional Token Embedding is applied first, and then the tokens are passed through $N_3$ Convolutional Transformer Blocks. This stage continues the process of feature extraction and refinement.\n5. **MLP Head**:\n   - After the three stages of processing, the output tokens are fed into an MLP (Multi - Layer Perceptron) Head. The MLP Head is responsible for making the final classification decision. It takes the high - level feature representation from the previous stages and maps it to a class label, indicating the category or action present in the video frame.\n\n### (b) Internal Structure of a Transformer Block\n1. **Multi - head Attention**:\n   - This is a key component of the Transformer block. It computes attention scores between different tokens in parallel across multiple \"heads\". Each head focuses on different aspects of the token relationships, allowing the model to capture a wide range of dependencies. The attention scores are calculated based on the query ($Q$), key ($K$), and value ($V$) matrices. These matrices are derived from the input tokens through linear projections.\n2. **Add & Normalize**:\n   - After the multi - head attention operation, the output is added to the input of the multi - head attention (a residual connection). This helps in training deeper networks by mitigating the vanishing gradient problem. Then, layer normalization is applied to the sum to stabilize the training process and improve the convergence rate.\n3. **MLP**:\n   - Following the Add & Normalize operation, the output passes through an MLP. The MLP further processes the features and helps in transforming the feature representation into a more suitable form for the next layer or for the final classification.\n4. **Convolutional Projection**:\n   - This component is likely used to project the features in a way that combines convolutional and Transformer - based processing. It might be used to re - organize or further transform the feature maps in a way that is beneficial for the overall network performance.\n\nIn summary, this architecture combines convolutional and Transformer - based operations to effectively process video frames, extracting both local and global features for classification tasks. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 22,
+                        "author": [
+                          "Junbin Xiao",
+                          "Pan Zhou",
+                          "Tat-Seng Chua",
+                          "Shuicheng Yan"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "This paper proposes a Video Graph Transformer (VGT) model for Video Quetion Answering (VideoQA). VGT's uniqueness are two-fold: 1) it designs a dynamic graph transformer module which encodes video by explicitly capturing the visual objects, their relations, and dynamics for complex spatio-temporal reasoning; and 2) it exploits disentangled video and text Transformers for relevance comparison between the video and text to perform QA, instead of entangled cross-modal Transformer for answer classification. Vision-text communication is done by additional cross-modal interaction modules. With more reasonable video encoding and QA solution, we show that VGT can achieve much better performances on VideoQA tasks that challenge dynamic relation reasoning than prior arts in the pretraining-free scenario. Its performances even surpass those models that are pretrained with millions of external data. We further show that VGT can also benefit a lot from self-supervised cross-modal pretraining, yet with orders of magnitude smaller data. These results clearly demonstrate the effectiveness and superiority of VGT, and reveal its potential for more data-efficient pretraining. With comprehensive analyses and some heuristic observations, we hope that VGT can promote VQA research beyond coarse recognition/description towards fine-grained relation reasoning in realistic videos. Our code is available at https://github.com/sail-sg/VGT.",
+                        "abstractZh": "本文提出了一种用于视频问答（VideoQA）的视频图变换器（VGT）模型。 VGT 的独特性有两个：1）它设计了一个动态图转换器模块，通过显式捕获视觉对象、它们的关系和动态来编码视频，以进行复杂的时空推理； 2）它利用解缠结的视频和文本 Transformer 进行视频和文本之间的相关性比较来执行 QA，而不是使用缠结的跨模态 Transformer 进行答案分类。视觉-文本通信是通过额外的跨模态交互模块来完成的。通过更合理的视频编码和 QA 解决方案，我们表明，在无预训练场景下，VGT 在挑战动态关系推理的 VideoQA 任务上可以取得比现有技术更好的性能。它的性能甚至超过了那些使用数百万外部数据进行预训练的模型。我们进一步表明，VGT 还可以从自监督跨模式预训练中受益匪浅，但数据量要小几个数量级。这些结果清楚地证明了 VGT 的有效性和优越性，并揭示了其数据效率更高的预训练的潜力。通过综合分析和一些启发式观察，我们希望 VGT 能够促进 VQA 研究超越粗略识别/描述，转向现实视频中的细粒度关系推理。我们的代码可在 https://github.com/sail-sg/VGT 获取。",
+                        "title": "Video Graph Transformer for Video Question Answering",
+                        "titleZh": "用于视频问答的视频图形转换器",
+                        "doi": "10.48550/arXiv.2207.05342",
+                        "bohriumId": "867764786199265870",
+                        "publicationId": 108597,
+                        "publicationCover": "https://assets.catalystplus.cn/journal_cover/arxiv.png",
+                        "publicationDate": "2022-07-12",
+                        "journal": "Computer Vision and Pattern Recognition",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.43305117476883936,
+                        "relevanceScore": 0.4632014036178589,
+                        "publicationScore": 0.5419512195121952,
+                        "impactFactor": 0,
+                        "impactFactorScore": 0.23370037670240518,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 23,
+                        "author": [
+                          "Li Li",
+                          "Liansheng Zhuang",
+                          "Shenghua Gao",
+                          "Shafei Wang"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Video transformers have become a promising tool for video classification due to its great success in modeling long-range interactions through the self-attention operation. However, existing transformer models only exploit the patch dependencies within a video when doing self-attention, while ignoring the patch dependencies across the different videos. This paper argues that external patch prior information is beneficial to the performance of video transformer models for video classification. Motivated by this assumption, this paper proposes a novel Hybrid-attention based Vision Transformer (HaViT) model for video classification, which explicitly exploits both internal patch dependencies within a video and external patch dependencies across videos. Different from existing self-attention, the hybrid-attention is computed based on internal patch tokens and an external patch token dictionary which encodes external patch prior information across the different videos. Experiments on Kinetics-400, Kinetics-600, and Something-Something v2 show that our HaViT model achieves state-of-the-art performance in the video classification task against existing methods. Moreover, experiments show that our proposed hybrid-attention scheme can be integrated into existing video transformer models to improve the performance.",
+                        "abstractZh": "",
+                        "title": "HaViT: Hybrid-Attention Based Vision Transformer for Video Classification",
+                        "titleZh": "",
+                        "doi": "10.1007/978-3-031-26316-3_30",
+                        "bohriumId": "1088849007490367495",
+                        "publicationId": 0,
+                        "publicationCover": "",
+                        "publicationDate": "2023-01-01",
+                        "journal": "ACCV (4)",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.43268515830772025,
+                        "relevanceScore": 0.4344612956047058,
+                        "publicationScore": 0.6263414634146341,
+                        "impactFactor": 0,
+                        "impactFactorScore": 0.23370037670240518,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 24,
+                        "author": [
+                          "Shusheng Yang",
+                          "Xinggang Wang",
+                          "Yu Li",
+                          "Yuxin Fang",
+                          "Jiemin Fang",
+                          "Wenyu Liu",
+                          "Xun Zhao",
+                          "Ying Shan"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Recently vision transformer has achieved tremendous success on image-level visual recognition tasks. To effectively and efficiently model the crucial temporal information within a video clip, we propose a Temporally Efficient Vision Transformer (TeViT) for video instance segmentation (VIS). Different from previous transformer-based VIS methods, TeViT is nearly convolution-free, which contains a transformer backbone and a query-based video instance segmentation head. In the backbone stage, we propose a nearly parameter-free messenger shift mechanism for early temporal context fusion. In the head stages, we propose a parameter-shared spatiotemporal query interaction mechanism to build the one-to-one correspondence between video instances and queries. Thus, TeViT fully utilizes both framelevel and instance-level temporal context information and obtains strong temporal modeling capacity with negligible extra computational cost. On three widely adopted VIS benchmarks, i.e., YouTube-VIS-2019, YouTube-VIS-2021, and OVIS, TeViT obtains state-of-the-art results and maintains high inference speed, e.g., 46.6 AP with 68.9 FPS on YouTube-VIS-2019. Code is available at https://github.com/hustvl/TeViT.",
+                        "abstractZh": "最近，视觉转换器在图像级视觉识别任务上取得了巨大的成功。为了有效且高效地对视频剪辑中的关键时间信息进行建模，我们提出了一种用于视频实例分割（VIS）的时间高效视觉变换器（TeViT）。与之前基于 Transformer 的 VIS 方法不同，TeViT 几乎是无卷积的，它包含一个 Transformer 主干和一个基于查询的视频实例分割头。在主干阶段，我们提出了一种几乎无参数的信使转移机制，用于早期时间上下文融合。在头部阶段，我们提出了一种参数共享的时空查询交互机制来建立视频实例和查询之间的一对一对应关系。因此，TeViT 充分利用帧级和实例级时间上下文信息，并以可忽略的额外计算成本获得强大的时间建模能力。在三个广泛采用的 VIS 基准（即 YouTube-VIS-2019、YouTube-VIS-2021 和 OVIS）上，TeViT 获得了最先进的结果并保持了较高的推理速度，例如 YouTube 上的 46.6 AP 和 68.9 FPS -视觉-2019。代码可在 https://github.com/hustvl/TeViT 获取。",
+                        "title": "Temporally Efficient Vision Transformer for Video Instance Segmentation",
+                        "titleZh": "用于视频实例分割的时间高效视觉转换器",
+                        "doi": "10.48550/arXiv.2204.08412",
+                        "bohriumId": "867756062256661453",
+                        "publicationId": 108597,
+                        "publicationCover": "https://assets.catalystplus.cn/journal_cover/arxiv.png",
+                        "publicationDate": "2022-04-18",
+                        "journal": "Computer Vision and Pattern Recognition",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.4128532919560475,
+                        "relevanceScore": 0.4433594048023224,
+                        "publicationScore": 0.5004878048780488,
+                        "impactFactor": 0,
+                        "impactFactorScore": 0.23370037670240518,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 25,
+                        "author": [
+                          "Oumaima Moutik",
+                          "Hiba Sekkat",
+                          "Smail Tigani",
+                          "Abdellah Chehri",
+                          "Rachid Saadane",
+                          "Taha Ait Tchakoucht",
+                          "Anand Paul"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Understanding actions in videos remains a significant challenge in computer vision, which has been the subject of several pieces of research in the last decades. Convolutional neural networks (CNN) are a significant component of this topic and play a crucial role in the renown of Deep Learning. Inspired by the human vision system, CNN has been applied to visual data exploitation and has solved various challenges in various computer vision tasks and video/image analysis, including action recognition (AR). However, not long ago, along with the achievement of the transformer in natural language processing (NLP), it began to set new trends in vision tasks, which has created a discussion around whether the Vision Transformer models (ViT) will replace CNN in action recognition in video clips. This paper conducts this trending topic in detail, the study of CNN and Transformer for Action Recognition separately and a comparative study of the accuracy-complexity trade-off. Finally, based on the performance analysis’s outcome, the question of whether CNN or Vision Transformers will win the race will be discussed.",
+                        "abstractZh": "理解视频中的动作仍然是计算机视觉领域的一项重大挑战，在过去几十年里，这一直是多项研究的主题。卷积神经网络（CNN）是该主题的一个重要组成部分，在深度学习的声誉中发挥着关键作用。受人类视觉系统的启发，CNN已被应用于视觉数据利用，并在各种计算机视觉任务和视频/图像分析中解决了各种挑战，包括动作识别（AR）。然而，不久前，随着Transformer在自然语言处理（NLP）领域取得的成就，它开始在视觉任务中引领新趋势，这引发了关于视觉Transformer模型（ViT）是否会在视频片段的动作识别中取代CNN的讨论。本文详细探讨了这个热门话题，分别研究了用于动作识别的CNN和Transformer，并对准确性与复杂性的权衡进行了比较研究。最后，基于性能分析的结果，将讨论CNN还是视觉Transformer将在这场竞争中胜出的问题。 ",
+                        "title": "Convolutional Neural Networks or Vision Transformers: Who Will Win the Race for Action Recognitions in Visual Data?",
+                        "titleZh": "卷积神经网络还是视觉Transformer：谁将在视觉数据的动作识别竞赛中胜出？",
+                        "doi": "10.3390/s23020734",
+                        "bohriumId": "864980402308120758",
+                        "publicationId": 4100,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/4100.png",
+                        "publicationDate": "2023-01-09",
+                        "journal": "Sensors",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "Understanding actions in videos remains a significant challenge in computer vision, which has been the subject of several pieces of research in the last decades. Convolutional neural networks (CNN) are a significant component of this topic and play a crucial role in the renown of Deep Learning.Inspired by the human vision system, CNN has been applied to visual data exploitation and has solved various challenges in various computer vision tasks and video/image analysis, including action recognition (AR). However, not long ago, along with the achievement of the transformer in natural language processing (NLP), it began to set new trends in vision tasks, which has created a discussion around whether the Vision Transformer models (ViT) will replace CNN in action recognition in video clips.This paper conducts this trending topic in detail, the study of CNN and Transformer for Action Recognition separately and a comparative study of the accuracy-complexity trade-off. Finally, based on the performance analysis’s outcome, the question of whether CNN or Vision Transformers will win the race will be discussed.",
+                        "sortScore": 0.40726558878643593,
+                        "relevanceScore": 0.42107561230659485,
+                        "publicationScore": 0.6302439024390244,
+                        "impactFactor": 3.4,
+                        "impactFactorScore": 0.14285714285714285,
+                        "citationNums": 49,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 26,
+                        "author": [
+                          "Hongchun Yuan",
+                          "Zhenyu Cai",
+                          "Hui Zhou",
+                          "Yue Wang",
+                          "Xiangzhi Chen"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Video anomaly detection is challenging because abnormal events are unbounded, rare, equivocal, irregular in real scenes. In recent years, transformers have demonstrated powerful modelling abilities for sequence data. Thus, we attempt to apply transformers to video anomaly detection. In this paper, we propose a prediction-based video anomaly detection approach named TransAnomaly. Our model combines the U-Net and the Video Vision Transformer (ViViT) to capture richer temporal information and more global contexts. To make full use of the ViViT for the prediction, we modified the ViViT to make it capable of video prediction. Experiments on benchmark datasets show that the addition of the transformer module improves the anomaly detection performance. In addition, we calculate regularity scores with sliding windows and evaluate the impact of different window sizes and strides. With proper settings, our model outperforms other state-of-the-art prediction-based video anomaly detection approaches. Furthermore, our model can perform anomaly localization by tracking the location of patches with lower regularity scores.",
+                        "abstractZh": "视频异常检测具有挑战性，因为异常事件在真实场景中是无限的、罕见的、模棱两可的、不规则的。近年来，Transformer 展示了强大的序列数据建模能力。因此，我们尝试将转换器应用于视频异常检测。在本文中，我们提出了一种名为 TransAnomaly 的基于预测的视频异常检测方法。我们的模型结合了 U-Net 和 Video Vision Transformer (ViViT) 来捕获更丰富的时间信息和更多的全局上下文。为了充分利用 ViViT 进行预测，我们修改了 ViViT 使其能够进行视频预测。在基准数据集上的实验表明，transformer 模块的加入提高了异常检测性能。此外，我们使用滑动窗口计算规律性分数，并评估不同窗口大小和步长的影响。通过适当的设置，我们的模型优于其他最先进的基于预测的视频异常检测方法。此外，我们的模型可以通过跟踪具有较低正则性分数的补丁的位置来执行异常定位。",
+                        "title": "TransAnomaly: Video Anomaly Detection Using Video Vision Transformer",
+                        "titleZh": "TransAnomaly：使用视频视觉转换器进行视频异常检测",
+                        "doi": "10.1109/access.2021.3109102",
+                        "bohriumId": "811866790572326913",
+                        "publicationId": 2649,
+                        "publicationCover": "https://assets.catalystplus.cn/journal_cover/2649.png",
+                        "publicationDate": "2021-01-01",
+                        "journal": "IEEE Access",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.402658684692737,
+                        "relevanceScore": 0.5333974361419678,
+                        "publicationScore": 0.2702439024390244,
+                        "impactFactor": 3.9,
+                        "impactFactorScore": 0.14285714285714285,
+                        "citationNums": 1,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 27,
+                        "author": [
+                          "Masato Tamura"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Social group activity recognition is a challenging task extended from group activity recognition, where social groups must be recognized with their activities and group members. Existing methods tackle this task by leveraging region features of individuals following existing group activity recognition methods. However, the effectiveness of region features is susceptible to person localization and variable semantics of individual actions. To overcome these issues, we propose leveraging attention modules in transformers to generate social group features. In this method, multiple embeddings are used to aggregate features for a social group, each of which is assigned to a group member without duplication. Due to this non-duplicated assignment, the number of embeddings must be significant to avoid missing group members and thus renders attention in transformers ineffective. To find optimal attention designs with a large number of embeddings, we explore several design choices of queries for feature aggregation and self-attention modules in transformer decoders. Extensive experimental results show that the proposed method achieves state-of-the-art performance and verify that the proposed attention designs are highly effective on social group activity recognition.",
+                        "abstractZh": "社会群体活动识别是群体活动识别的延伸，是一项具有挑战性的任务，必须通过其活动和群体成员来识别社会群体。现有方法通过利用现有群体活动识别方法中个体的区域特征来解决此任务。然而，区域特征的有效性容易受到人员定位和个体动作的可变语义的影响。为了克服这些问题，我们建议利用 Transformer 中的注意力模块来生成社交群体特征。在该方法中，使用多个嵌入来聚合社交群组的特征，每个特征被分配给群组成员而不重复。由于这种非重复分配，嵌入的数量必须很大，以避免丢失组成员，从而使变压器的注意力无效。为了找到具有大量嵌入的最佳注意力设计，我们探索了变压器解码器中特征聚合和自注意力模块的查询的几种设计选择。大量的实验结果表明，所提出的方法实现了最先进的性能，并验证了所提出的注意力设计在社交群体活动识别方面非常有效。",
+                        "title": "Design and Analysis of Efficient Attention in Transformers for Social Group Activity Recognition",
+                        "titleZh": "用于社会群体活动识别的Transformer中高效注意力机制的设计与分析",
+                        "doi": "10.1007/s11263-024-02082-y",
+                        "bohriumId": "995508298893492232",
+                        "publicationId": 2473,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2473.png",
+                        "publicationDate": "2024-05-10",
+                        "journal": "International Journal of Computer Vision",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.3736766881131571,
+                        "relevanceScore": 0.1710611879825592,
+                        "publicationScore": 0.8678048780487805,
+                        "impactFactor": 11.6,
+                        "impactFactorScore": 0.48739495798319327,
+                        "citationNums": 1,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "995508298893492232_fig5_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/2473/995508298893492232/995508298893492232_fig5_1.png",
+                            "enExplain": "The image illustrates a complex architecture for human - related recognition tasks in video sequences, likely focusing on both individual and group - level analysis. Here is a detailed breakdown:\n\n### Input and Initial Feature Extraction\n1. **Frame sequence \\(x\\)**: The input is a sequence of video frames. This sequence is first processed by an I3D (Inflated 3D) network on the RGB stream. The I3D network is designed to capture spatio - temporal features from the video frames. After processing through the I3D network, a set of feature maps \\(Z_f\\) is obtained.\n2. **Temporal processing**: The feature maps \\(Z_f\\) are then subjected to temporal average pooling, which aggregates the features over time. Following this, a projection convolution is applied to obtain modified feature maps \\(Z_p\\).\n\n### Feature Refinement with Transformer\n1. **Transformer encoder**: The modified feature maps \\(Z_p\\) are fed into a Transformer encoder. Positional encodings \\(P\\) are added to the input to provide information about the position of elements in the sequence. The output of the Transformer encoder is refined feature maps \\(Z_e\\).\n\n### Decoding for Individual and Group Recognition\n1. **Individual transformer decoder**: The refined feature maps \\(Z_e\\) are processed by an individual transformer decoder. Query embeddings \\(Q_{id}\\) are used in this process. The output of the individual decoder is feature embeddings \\(H_{id}\\), which are then fed into several heads for different tasks:\n    - **Person class head**: Responsible for classifying the type of person (e.g., age, gender - related classes).\n    - **Box head**: Predicts bounding boxes around individuals in the video frames.\n    - **Action head**: Recognizes the actions performed by individuals, such as \"Standing\" or \"Moving\" as shown in the example.\n2. **Group transformer decoder**: The refined feature maps \\(Z_e\\) are also processed by a group transformer decoder. Group query embeddings \\(Q_{gr}\\) are used here, which consist of a group query \\(Q_{gr}^{(g)}\\) and query embeddings for each group. The output of the group decoder is feature embeddings \\(H_{gr}\\), which are then fed into different heads:\n    - **Group size head**: Estimates the size of the group (number of members).\n    - **Member point head**: Identifies specific points related to group members.\n    - **Activity head**: Recognizes the group - level activities, such as the \"Right set\" shown in the example related to a sports event.\n\n### Self - Attention and Cross - Attention in Group Transformer\nThe group transformer decoder makes use of self - attention and cross - attention mechanisms. Self - attention allows the model to weigh the importance of different elements within the same group of query embeddings. Cross - attention enables the model to attend to the refined feature maps \\(Z_e\\) while processing the group query embeddings. A feed - forward network (FNN) is also part of the processing pipeline within the group transformer decoder.\n\n### Output and Identification\n1. **Group member identifier**: There is a component labeled as the \"Group member identifier\" which likely uses the outputs from both the individual and group recognition paths to identify and associate individual members with their respective groups.\n2. **Recognition paths**: The individual recognition path (blue arrows) focuses on per - individual tasks like action recognition and bounding box prediction. The group recognition path (red arrows) is concerned with group - level tasks such as group activity recognition and group size estimation.\n\nOverall, this architecture combines 3D convolutional features from video frames with Transformer - based processing to perform comprehensive individual and group - level recognition in video sequences. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 28,
+                        "author": [
+                          "Wenjun Zhu",
+                          "Li Xu",
+                          "Jun Meng"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Self-supervised learning (SSL) performs remarkably in visual tracking since it enables the extraction of general representations from unlabeled data and alleviates the need for expensive human annotations. SSL models usually achieve frame-to-frame communications during training by predicting each object location of intermediate frames, however, the possible prediction errors may accumulate and mislead the forward–backward tracking procedure. A novel query-communication transformer (QCT) architecture is proposed in this work to enable more reliable frame-to-frame communications via propagating query information, avoiding the above-mentioned tracking errors on intermediate frames tactfully. Specifically, we introduce the transformer into self-supervised tracking to handle the object template and search frames, i.e., the encoder encodes spatio-temporal context of template and search frames, while the decoder takes the query embedding of previous frame to retrieve the template object information from the encoder output. To further enhance the query embedding, a query interaction module is devised to promote information passing between frames. Moreover, we employ inter-frame correspondence and intra-frame correspondence to construct different views and transformations for better learning the representation from palindromic sequences. We validate our method on the seven challenging benchmarks. The results demonstrate considerable improvements over recent self-supervised algorithms and even some fully-supervised deep trackers.",
+                        "abstractZh": "自监督学习（SSL）在视觉跟踪中表现出色，因为它能够从未标记数据中提取通用表示，并减少对昂贵人工标注的需求。SSL模型通常在训练期间通过预测中间帧的每个对象位置来实现帧到帧的通信，然而，可能的预测误差可能会累积并误导前后跟踪过程。在这项工作中，我们提出了一种新颖的查询通信变换器（QCT）架构，通过传播查询信息来实现更可靠的帧到帧通信，巧妙地避免了中间帧上的上述跟踪误差。具体来说，我们将变换器引入自监督跟踪中，以处理对象模板和搜索帧，即编码器对模板和搜索帧的时空上下文进行编码，而解码器以前一帧的查询嵌入从编码器输出中检索模板对象信息。为了进一步增强查询嵌入，我们设计了一个查询交互模块来促进帧之间的信息传递。此外，我们采用帧间对应和帧内对应来构建不同的视图和变换，以便更好地从回文序列中学习表示。我们在七个具有挑战性的基准上验证了我们的方法。结果表明，与最近的自监督算法甚至一些全监督深度跟踪器相比，有了显著的改进。 ",
+                        "title": "Consistency-based self-supervised visual tracking by using query-communication transformer",
+                        "titleZh": "基于一致性的自监督视觉跟踪：使用查询通信变换器",
+                        "doi": "10.1016/j.knosys.2023.110849",
+                        "bohriumId": "892255116856394341",
+                        "publicationId": 2446,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2446.png",
+                        "publicationDate": "2023-07-30",
+                        "journal": "Knowledge-Based Systems",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.36305886797304215,
+                        "relevanceScore": 0.2613309323787689,
+                        "publicationScore": 0.728780487804878,
+                        "impactFactor": 7.2,
+                        "impactFactorScore": 0.3025210084033613,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "892255116856394341_fig3_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/2446/892255116856394341/892255116856394341_fig3_1.png",
+                            "enExplain": "The diagram illustrates a sophisticated framework for processing sparse - sampled video frames to predict boundaries.\n\n### 1. Input and Initial Steps\n- **Sparse Sampled Video Frames**: The process starts with a set of sparsely sampled video frames, which are the initial input to the system. These frames are likely selected to reduce computational complexity while still capturing key information in the video.\n- **Dynamic Time Selection & Transformation**: This step involves selecting and transforming the frames in a dynamic way. It aims to find inter - frame correspondence (relationship between different frames) or intra - frame correspondence (relationship within a single frame). This is crucial for understanding the motion and structure within the video content.\n\n### 2. Pseudo - Boundary Generation\n- **Pseudo - Boundary**: A pseudo - boundary is generated, which is an initial estimate of the boundary within the video frames. This serves as a starting point for further processing.\n\n### 3. Boundary Processing\n- **Boundary Processing**: The pseudo - boundary and the video frames ($x_1$, $x_2$, etc.) are processed separately through Convolutional Neural Networks (CNNs). The CNNs extract local features from the frames and the boundary information. The outputs of the CNNs are then flattened and concatenated. This combined feature vector is a crucial representation that captures both the frame - level and boundary - level information.\n\n### 4. Transformer Encoder and Decoder\n- **Transformer Encoder**: The flattened and concatenated feature vectors are fed into a series of Transformer Encoders. The Transformer Encoder is a key component in processing sequential data. It uses self - attention mechanisms to capture long - range dependencies in the data. Each Transformer Encoder ($F^1$, $F^2$, $F^3$, $F^4$) processes the input feature vectors and outputs a more refined representation.\n- **Transformer Decoder**: The outputs of the Transformer Encoders are then used by the Transformer Decoders. The decoders take an initial query ($q_0$) and transform it through a series of operations. Quadratic Integer Minimization (QIM) is applied at each step of the decoder to refine the query. The output of the final Transformer Decoder is used to predict the boundary.\n\n### 5. Consistency Loss and Prediction\n- **Consistency Loss**: A consistency loss is calculated to ensure that the predicted boundary is consistent with the input frames and the pseudo - boundary. This loss function helps in training the model to make accurate boundary predictions.\n- **Predicted Boundary**: The final output of the framework is the predicted boundary, which is generated by the prediction head. This boundary represents the model's estimate of the important regions or objects within the video frames.\n\n### 6. Additional Components\n- **2D Position Encoding**: This component is used to add positional information to the feature vectors. In a video context, position information is crucial for understanding the spatial and temporal relationships between different elements in the frames.\n- **Initial Query**: The initial query ($q_0$) is the starting point for the Transformer Decoder operations. It is gradually refined through the decoder layers to generate the final prediction.\n\nOverall, this framework combines CNNs for local feature extraction and Transformers for handling long - range dependencies to accurately predict boundaries in sparse - sampled video frames. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 29,
+                        "author": [
+                          "Licai Sun",
+                          "Zheng Lian",
+                          "Bin Liu",
+                          "Jianhua Tao"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Audio-Visual Emotion Recognition (AVER) has garnered increasing attention in recent years for its critical role in creating emotion-aware intelligent machines. Previous efforts in this area are dominated by the supervised learning paradigm. Despite significant progress, supervised learning is meeting its bottleneck due to the longstanding data scarcity issue in AVER. Motivated by recent advances in self-supervised learning, we propose Hierarchical Contrastive Masked Autoencoder (HiCMAE), a novel self-supervised framework that leverages large-scale self-supervised pre-training on vast unlabeled audio-visual data to promote the advancement of AVER. Following prior arts in self-supervised audio-visual representation learning, HiCMAE adopts two primary forms of self-supervision for pre-training, namely masked data modeling and contrastive learning. Unlike them which focus exclusively on top-layer representations while neglecting explicit guidance of intermediate layers, HiCMAE develops a three-pronged strategy to foster hierarchical audio-visual feature learning and improve the overall quality of learned representations. Firstly, it incorporates hierarchical skip connections between the encoder and decoder to encourage intermediate layers to learn more meaningful representations and bolster masked audio-visual reconstruction. Secondly, hierarchical cross-modal contrastive learning is also exerted on intermediate representations to narrow the audio-visual modality gap progressively and facilitate subsequent cross-modal fusion. Finally, during downstream fine-tuning, HiCMAE employs hierarchical feature fusion to comprehensively integrate multi-level features from different layers. To verify the effectiveness of HiCMAE, we conduct extensive experiments on 9 datasets covering both categorical and dimensional AVER tasks. Experimental results show that our method significantly outperforms state-of-the-art supervised and self-supervised audio-visual methods, which indicates that HiCMAE is a powerful audio-visual emotion representation learner. Codes and models are publicly available at https://github.com/sunlicai/HiCMAE.",
+                        "abstractZh": "视听情感识别（AVER）近年来因其在创建情感感知智能机器中的关键作用而受到越来越多的关注。该领域以前的工作主要由监督学习范式主导。尽管取得了重大进展，但由于AVER中长期存在的数据稀缺问题，监督学习正面临瓶颈。受自监督学习最新进展的启发，我们提出了分层对比掩码自动编码器（HiCMAE），这是一种新颖的自监督框架，它利用对大量未标记视听数据进行大规模自监督预训练来推动AVER的发展。遵循自监督视听表示学习的现有技术，HiCMAE采用两种主要的自监督形式进行预训练，即掩码数据建模和对比学习。与它们只专注于顶层表示而忽略中间层的明确指导不同，HiCMAE制定了三管齐下的策略来促进分层视听特征学习并提高学习表示的整体质量。首先，它在编码器和解码器之间合并分层跳跃连接，以鼓励中间层学习更有意义的表示并加强掩码视听重建。其次，还对中间表示施加分层跨模态对比学习，以逐步缩小视听模态差距并促进后续的跨模态融合。最后，在下游微调期间，HiCMAE采用分层特征融合来全面整合来自不同层的多级特征。为了验证HiCMAE的有效性，我们在9个涵盖分类和维度AVER任务的数据集上进行了广泛的实验。实验结果表明，我们的方法显著优于当前最先进的监督和自监督视听方法，这表明HiCMAE是一个强大的视听情感表示学习器。代码和模型可在https://github.com/sunlicai/HiCMAE上公开获取。 ",
+                        "title": "HiCMAE: Hierarchical Contrastive Masked Autoencoder for self-supervised Audio-Visual Emotion Recognition",
+                        "titleZh": "HiCMAE：用于自监督视听情感识别的分层对比掩码自动编码器",
+                        "doi": "10.1016/j.inffus.2024.102382",
+                        "bohriumId": "985494697596158299",
+                        "publicationId": 2426,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2426.png",
+                        "publicationDate": "2024-08-01",
+                        "journal": "Information Fusion",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.3420802820591966,
+                        "relevanceScore": 0.060086652636528015,
+                        "publicationScore": 0.9082926829268293,
+                        "impactFactor": 14.8,
+                        "impactFactorScore": 0.6218487394957983,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "985494697596158299_fig4_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/2426/985494697596158299/985494697596158299_fig4_1.png",
+                            "enExplain": "### Overall Structure and Context\nThe image depicts a schematic diagram of a video - related neural network architecture, specifically a video encoder - decoder structure. This type of architecture is commonly used in tasks such as video compression, video generation, and video understanding. The diagram is divided into two main parts: the Video Encoder on the left - hand side and the Video Decoder on the right - hand side.\n\n### Video Encoder\n1. **General Function**: The Video Encoder's primary role is to take in video input (represented by the stack of red - colored rectangular blocks at the bottom left) and transform it into a more compact and meaningful representation. This is achieved through a series of processing steps.\n2. **Transformer Layers**: The encoder consists of multiple Transformer Layers. Each Transformer Layer is a key component in the architecture, designed to process sequential data effectively. The Transformer architecture, which was originally proposed for natural language processing tasks, has been adapted here for video processing.\n    - **Stacking of Layers**: There are multiple Transformer Layers stacked on top of each other. This stacking allows the encoder to extract hierarchical features from the video data. As the data passes through each layer, it captures different levels of abstraction, from low - level visual features to high - level semantic features.\n    - **Skip Connections**: Skip connections (the purple arrows) are present between the encoder layers. These connections help in mitigating the vanishing gradient problem and also allow the model to combine features from different layers more effectively. By directly adding the output of an earlier layer to a later layer, the network can learn more robust and diverse features.\n\n### Video Decoder\n1. **General Function**: The Video Decoder aims to reconstruct the original video or generate a related video output from the encoded representation received from the encoder. It takes the output of the encoder and gradually transforms it back into a video - like format (represented by the stack of image - like blocks at the top right).\n2. **Transformer Layers**: Similar to the encoder, the decoder also contains multiple Transformer Layers. These layers work in reverse to the encoder layers, gradually expanding the encoded representation back into a full - fledged video.\n3. **Multi - Head Attention Mechanisms**:\n    - **MHCA (Multi - Head Causal Attention)**: In the decoder, MHCA is used. Causal attention ensures that when generating a particular frame or part of the video, the model only attends to previous frames (in a sequential manner). This is crucial for tasks where the order of frames matters, such as video generation. For example, when generating a new frame, the model should base its output on the already generated frames and the encoded information.\n    - **MHSA (Multi - Head Self - Attention)**: Another type of multi - head attention mechanism used in the decoder. Self - attention allows the model to weigh the importance of different parts of the input sequence (in this case, the encoded representation) when generating the output. It helps in capturing long - range dependencies within the video data.\n4. **FFN (Feed - Forward Network)**: Each Transformer Layer in the decoder also contains a Feed - Forward Network. The FFN is a simple neural network that further processes the output of the attention mechanisms. It helps in introducing non - linearity into the model, enabling it to learn complex relationships in the data.\n\n### Input and Output Representation\n1. **Input**: The input to the Video Encoder is represented as a stack of video - related data blocks (red - colored). This could be raw video frames or pre - processed feature maps.\n2. **Output**: The output of the Video Decoder is a stack of image - like blocks (top right), which could represent the reconstructed video frames or the generated video frames depending on the task.\n\nIn summary, this video encoder - decoder architecture, with its use of Transformer Layers, attention mechanisms, and skip connections, is designed to handle video data in a way that can capture sequential and hierarchical features effectively for various video - related tasks. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 30,
+                        "author": [
+                          "Chia-Hung Yeh",
+                          "Hsin-Fu Yang",
+                          "Yu-Yang Lin",
+                          "Wan-Jen Huang",
+                          "Feng-Hsu Tsai",
+                          "Li-Wei Kang"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "This paper addresses the problem for fine-grained video super-resolution (FGVSR) to suppress temporal flickering caused by separately processed consecutive frames and enhance the quality of restored video frame details when upsizing videos. Some existing video SR methods fail to sufficiently utilize spatial-temporal information from input low-resolution (LR) videos, while others may generate undesirable artifacts or cannot well reconstruct image details. To overcome these problems, we present a novel deep learning framework for FGVSR, which takes a set of consecutive LR video frames and generate the corresponding super-resolved frames. Our deep FGVSR framework focuses on reconstructing missing information from the LR sources based on the proposed multi-frame alignment and refinement strategies. More specifically, we propose an alignment module, where multiple frames are aligned at feature level, to prevent the output videos from flickering. Then, we introduce a feature fusion module, where aligned features generated from our alignment module are fused and refined in a multi-scale manner. Finally, the proposed refinement module is used to reconstruct missing information based on the fused features. In addition, we also embed an image enhancement module on the skip connection from the input layer to the output layer of our network for further enhancing the SR results. Experimental results show that the proposed deep FGVSR, compared with existing deep learning-based VSR methods, achieves state-of-the-art performances on the three well-known benchmarks, including REDS, Vid4, and Vimeo90k. More specifically, compared with the state-of-the-art VSR methods in our experiments, our FGVSR achieves quantitative improvements from 0.70 dB to 9.54 dB in PSNR . On the other hand, our method has also been shown to be efficient to other image restoration tasks, such as image inpainting.",
+                        "abstractZh": "本文解决了细粒度视频超分辨率（FGVSR）的问题，以抑制单独处理的连续帧引起的时间闪烁，并在放大视频时提高恢复视频帧细节的质量。一些现有的视频 SR 方法无法充分利用输入低分辨率 (LR) 视频中的时空信息，而其他方法可能会产生不良伪影或无法很好地重建图像细节。为了克服这些问题，我们提出了一种新颖的 FGVSR 深度学习框架，该框架采用一组连续的 LR 视频帧并生成相应的超分辨率帧。我们的深层 FGVSR 框架专注于根据所提出的多帧对齐和细化策略从 LR 源重建丢失的信息。更具体地说，我们提出了一个对齐模块，其中多个帧在特征级别对齐，以防止输出视频闪烁。然后，我们引入一个特征融合模块，其中从我们的对齐模块生成的对齐特征以多尺度方式融合和细化。最后，所提出的细化模块用于基于融合特征重建丢失的信息。此外，我们还在网络输入层到输出层的跳跃连接上嵌入了图像增强模块，以进一步增强 SR 结果。实验结果表明，与现有的基于深度学习的 VSR 方法相比，所提出的深度 FGVSR 在 REDS、Vid4 和 Vimeo90k 等三个著名基准上实现了最先进的性能。更具体地说，与我们实验中最先进的 VSR 方法相比，我们的 FGVSR 在 PSNR 方面实现了从 0.70 dB 到 9.54 dB 的定量改进。另一方面，我们的方法也被证明对其他图像恢复任务有效，例如图像修复。",
+                        "title": "Fine-grained video super-resolution via spatial-temporal learning and image detail enhancement",
+                        "titleZh": "通过时空学习和图像细节增强实现细粒度视频超分辨率",
+                        "doi": "10.1016/j.engappai.2023.107789",
+                        "bohriumId": "949532625473634346",
+                        "publicationId": 2472,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2472.png",
+                        "publicationDate": "2024-01-03",
+                        "journal": "Engineering Applications of Artificial Intelligence",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.3392580582495719,
+                        "relevanceScore": 0.1919327825307846,
+                        "publicationScore": 0.8053658536585366,
+                        "impactFactor": 7.5,
+                        "impactFactorScore": 0.31512605042016806,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "949532625473634346_fig11_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/2472/949532625473634346/949532625473634346_fig11_1.png",
+                            "enExplain": "This image is a comparison grid showcasing different image - enhancement or super - resolution techniques applied to a set of photographs.\n\n### Structure and Content\nThe grid is organized into columns and rows. Each column contains a sequence of images from a single scene, likely from a wedding event, as indicated by the presence of a bride cutting a cake, guests, and formal attire.\n\n- **Rows**: There are eight rows in total, each labeled with a different method or technology used for image processing. From top to bottom, the labels are: \"Input\", \"EDVR\", \"TecoGAN\", \"SOF\", \"Transformer\", \"EGVSR\", \"Ours\", and \"GT\" (which stands for Ground Truth).\n  - **Input**: The first row represents the original, un - enhanced images. These are the base images to which the various techniques are applied.\n  - **EDVR**: This row shows the results of the EDVR (Enhanced Deep Video Restoration) technique. EDVR is designed to restore and enhance video frames, and here it is applied to still images from the sequence.\n  - **TecoGAN**: The third row displays the output of the TecoGAN method. TecoGAN is a generative adversarial network - based approach for video super - resolution and enhancement.\n  - **SOF**: The SOF row presents the results of the SOF (presumably a specific super - resolution or enhancement algorithm) technique.\n  - **Transformer**: This row shows the results achieved using a Transformer - based approach. Transformers have been widely used in natural language processing and are increasingly being applied to computer vision tasks such as image enhancement.\n  - **EGVSR**: The EGVSR row represents the results of the EGVSR (Enhanced Global Video Super - Resolution) method.\n  - **Ours**: This row showcases the results of the method developed by the authors of the comparison. It is likely being presented as a competitive or superior alternative to the other techniques.\n  - **GT (Ground Truth)**: The last row represents the high - quality, original or reference images against which the performance of the other methods is compared.\n\n- **Columns**: Each column captures a different moment or angle within the wedding scene. For example, one column shows a woman in a dress smiling, another shows the bride cutting the cake, and others show guests interacting.\n\n### Purpose\nThe purpose of this grid is to visually compare the effectiveness of different image - processing techniques. By presenting the original \"Input\" images, the results of various well - known methods, and the \"Ground Truth\" images, viewers can easily assess which technique produces results that are closest to the high - quality reference images. This kind of comparison is useful in the field of computer vision for evaluating and promoting new algorithms for image enhancement and super - resolution. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 31,
+                        "author": [
+                          "Tianhang Zhang",
+                          "Fangqiang Ding",
+                          "Zilong Wang",
+                          "Fu Xiao",
+                          "Chris Xiaoxuan Lu",
+                          "Xinyan Huang"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Experienced firefighters can fuse the flame image, smoke pattern, and varying temperature, sound, and odour in complex and fast-changing fire scenes to foresee flashover and explosion. This study mimics firefighters and proposes a novel transformer algorithm for the fusion of fire images and temperature sensor data to forecast the backdraft explosion in a building fire. The model of backdraft forecast is demonstrated with full-scale fire tests. After training 2674 fire scenarios with various fire intensities and images from various view angles, the Fusion-Transformer model can forecast the risk of backdraft with an overall accuracy of 84%. Moreover, the occurrence time and explosion scale of backdraft can be predicted with the Mean Absolute Error (MAE) of 1.6 s and 0.14 m, respectively. Compared with the single modal model, the fusion of fire images and temperature sensor data improves the accuracy of backdraft forecast by over 50%. This work demonstrates the use of a transformer algorithm in forecasting fire evolution and critical events. It also bridges the gap between data fusion methods and fire forecast, which inspires future universal AI-driven smart firefighting practices.",
+                        "abstractZh": "经验丰富的消防员可以在复杂且快速变化的火灾场景中融合火焰图像、烟雾模式以及变化的温度、声音和气味，从而预见闪络和爆炸。这项研究模仿消防员，提出了一种新颖的变压器算法，用于融合火灾图像和温度传感器数据，以预测建筑物火灾中的回燃爆炸。通过全面的火灾试验验证了回燃预测模型。经过对 2674 个不同火灾强度和不同视角图像的火灾场景进行训练后，Fusion-Transformer 模型可以预测回燃风险，总体准确率达到 84%。此外，可以用平均绝对误差（MAE）分别为1.6 s和0.14 m来预测逆燃的发生时间和爆炸规模。与单模态模型相比，火灾图像与温度传感器数据的融合使逆燃预报精度提高了50%以上。这项工作演示了变压器算法在预测火灾演变和重大事件中的用途。它还弥合了数据融合方法和火灾预测之间的差距，激发了未来通用人工智能驱动的智能消防实践。",
+                        "title": "Forecasting backdraft with multimodal method: Fusion of fire image and sensor data",
+                        "titleZh": "基于多模态方法的回燃预测：火灾图像与传感器数据的融合",
+                        "doi": "10.1016/j.engappai.2024.107939",
+                        "bohriumId": "958549353578889221",
+                        "publicationId": 2472,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2472.png",
+                        "publicationDate": "2024-01-28",
+                        "journal": "Engineering Applications of Artificial Intelligence",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.33669359143329475,
+                        "relevanceScore": 0.18359363079071045,
+                        "publicationScore": 0.817560975609756,
+                        "impactFactor": 7.5,
+                        "impactFactorScore": 0.31512605042016806,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "958549353578889221_fig5_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/2472/958549353578889221/958549353578889221_fig5_1.png",
+                            "enExplain": "### (a) Overall Architecture\nThe image depicts a complex neural - network architecture for processing sensor and vision signals.\n\n1. **Input Signals**\n   - **Sensor Signal**:\n     - The sensor signal is represented as a time - sequence of length 120 seconds. It consists of data from multiple sensors, as indicated by the matrix \\(T_{H}\\). Each row in the matrix represents a different sensor (e.g., \\(T_{U,119}\\) and \\(T_{L,119}\\) are sensor - specific values at time step 119), and there are two types of sensors denoted by \\(U\\) and \\(L\\). The number of sensors is denoted as \\(Z\\).\n   - **Vision Signal**:\n     - The vision signal is a sequence of video frames. Each frame has a height of 720 pixels and a width of 1080 pixels, and there are 3 color channels (RGB). The time - sequence of these frames also has a length of 120 seconds.\n\n2. **Encoder Layers**\n   - **Transformer Encoder (Sensor)**:\n     - This encoder processes the sensor signal. It first applies self - attention to the sensor data. Self - attention allows the model to weigh the importance of different parts of the sensor signal at different time steps and across different sensors.\n   - **Transformer Encoder (Image)**:\n     - For the vision signal, the RGB frames are first divided into patches. These patches are then projected into a lower - dimensional space using a video projection \\(E_{vp}\\). Position embeddings are added to the patches to account for their spatial position within the frame. The resulting embeddings are then processed by the Transformer Encoder (Image) using self - attention.\n\n3. **Fusion Layer**\n   - **Fusion - Transformer Encoder**:\n     - This layer combines the features from the Sensor Transformer Encoder and the Image Transformer Encoder. It uses fusion - attention to integrate the information from both modalities. The fused features are then further processed.\n\n4. **Decoder and Predictions**\n   - **LSTM Decoder**:\n     - The output of the Fusion - Transformer Encoder is fed into an LSTM decoder. The LSTM decoder is used for tasks such as backdraft prediction.\n   - **MLP for Chamber Fire Observation**:\n     - Another output path from the Fusion - Transformer Encoder is fed into a Multi - Layer Perceptron (MLP) for chamber fire observation.\n\n### (b) Transformer Encoder Block\n1. **Input**:\n   - The input to the Transformer Encoder block is embedded patches. These patches are likely the output of the patch - embedding and position - embedding steps in the Transformer Encoder (Image) or similar processing in the Sensor Transformer Encoder.\n2. **Multi - head Attention**:\n   - The multi - head attention mechanism takes the query (\\(Q\\)), key (\\(K\\)), and value (\\(V\\)) vectors from the embedded patches. It computes multiple attention heads in parallel, which allows the model to capture different relationships within the data. The output of the multi - head attention is then added to the original input (residual connection) and normalized (Add & Norm).\n3. **Feed - Forward Layer**:\n   - The output of the Add & Norm step is fed into a feed - forward neural network. This layer further processes the features. After the feed - forward layer, another residual connection and normalization step (Add & Norm) are applied, and the result is the output of the Transformer Encoder block. This block is repeated \\(L\\) times in the overall Transformer Encoder architecture to capture more complex patterns in the data. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 32,
+                        "author": [
+                          "Yifan Song",
+                          "Shengmao Zhang",
+                          "Fenghua Tang",
+                          "Yongchuang Shi",
+                          "Yumei Wu",
+                          "Jianwen He",
+                          "Yunyun Chen",
+                          "Lin Li"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "In recent years, with the development of pelagic fishing, the working environment and monitoring of crew (squid jigger) members have become increasingly important. However, traditional methods of pelagic human observers suffer from high costs, low coverage, poor timeliness, and susceptibility to subjective factors. In contrast, the Electronic Monitoring System (EMS) has advantages such as continuous operation under various weather conditions; more objective, transparent, and efficient data; and less interference with fishing operations. This paper shows how the 3DCNN model, LSTM+ResNet model, and TimeSformer model are applied to video-classification tasks, and for the first time, they are applied to an EMS. In addition, this paper tests and compares the application effects of the three models on video classification, and discusses the advantages and challenges of using them for video recognition. Through experiments, we obtained the accuracy and relevant indicators of video recognition using different models. The research results show that when NUM_FRAMES is set to 8, the LSTM+ResNet-50 model has the best performance, with an accuracy of 88.47%, an F1 score of 0.8881, and an map score of 0.8133. Analyzing the EMS for pelagic fishing can improve China’s performance level and management efficiency in pelagic fishing, and promote the development of the fishery knowledge service system and smart fishery engineering.",
+                        "abstractZh": "近年来，随着远洋渔业的发展，船员（鱿鱼钓船船员）的工作环境和监测变得越来越重要。然而，传统的远洋人工观测方法存在成本高、覆盖范围低、时效性差以及易受主观因素影响等问题。相比之下，电子监测系统（EMS）具有在各种天气条件下持续运行、数据更客观、透明和高效以及对捕鱼作业干扰较小等优点。本文展示了三维卷积神经网络（3DCNN）模型、长短期记忆网络与残差网络结合（LSTM+ResNet）模型和时空变换器（TimeSformer）模型如何应用于视频分类任务，并且首次将它们应用于电子监测系统。此外，本文测试并比较了这三种模型在视频分类上的应用效果，并讨论了将它们用于视频识别的优点和挑战。通过实验，我们获得了使用不同模型进行视频识别的准确率及相关指标。研究结果表明，当帧数（NUM_FRAMES）设置为8时，LSTM+ResNet-50模型性能最佳，准确率为88.47%，F1分数为0.8881，平均精度均值（map）分数为0.8133。对远洋渔业电子监测系统进行分析可以提高中国远洋渔业的作业水平和管理效率，推动渔业知识服务系统和智能渔业工程的发展。 ",
+                        "title": "Behavior Recognition of Squid Jigger Based on Deep Learning",
+                        "titleZh": "基于深度学习的鱿鱼钓机行为识别",
+                        "doi": "10.3390/fishes8100502",
+                        "bohriumId": "949256937533341746",
+                        "publicationId": 1699,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/1699.png",
+                        "publicationDate": "2023-10-08",
+                        "journal": "Fishes",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.3243316354932678,
+                        "relevanceScore": 0.2568320035934448,
+                        "publicationScore": 0.7629268292682927,
+                        "impactFactor": 2.1,
+                        "impactFactorScore": 0.08823529411764706,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "949256937533341746_fig5_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/1699/949256937533341746/949256937533341746_fig5_1.png",
+                            "enExplain": "The provided diagram illustrates the architecture of a Timesformer block, which is designed for processing video - related data. Here is a detailed breakdown:\n\n### Input and Initial Processing\n1. **Frames**: The starting point is a set of video frames. This represents the raw input data that the model will operate on. Video frames capture visual information over time and form the basis for understanding dynamic scenes.\n2. **VIT (Vision Transformer)**: The frames are first processed through a Vision Transformer. This step divides the frames into patches. Patches are smaller, fixed - sized regions that are created by splitting the frames. The idea is to break down the large - scale visual information into more manageable pieces for further processing.\n3. **Linearly Map**: After obtaining the patches, they are linearly mapped. This linear transformation is used to project the patch data into a suitable feature space that can be effectively processed by the subsequent components.\n\n### Timesformer Block\nThe main part of the diagram is the Timesformer block, which consists of multiple sub - components and operations:\n\n#### Left Branch\n1. **Z(l - 1)**: This represents the input feature map to the current layer of the Timesformer block. It is the output from the previous layer (l - 1).\n2. **Time Attention**: This module focuses on the temporal relationships between the frames. In video data, understanding how different frames are related over time is crucial for tasks such as action recognition. Time Attention calculates attention scores across different time steps (frames) to capture temporal dependencies.\n3. **Add&Norm**: After the Time Attention operation, a residual connection (Add) and layer normalization (Norm) are applied. The residual connection helps in gradient flow during training and allows the model to learn more complex functions by adding the input to the output of the attention module. Layer normalization normalizes the output to have zero mean and unit variance, which helps in stabilizing the training process.\n4. **Width Attention**: This attention module focuses on the spatial relationships in the width dimension of the patches. It calculates attention scores across different width positions within the patches to capture spatial information in the horizontal direction.\n5. **Add&Norm**: Similar to the previous step, another residual connection and layer normalization are applied after the Width Attention operation.\n\n#### Right Branch\n1. **Height Attention**: This module focuses on the spatial relationships in the height dimension of the patches. It calculates attention scores across different height positions within the patches to capture spatial information in the vertical direction.\n2. **Add&Norm**: A residual connection and layer normalization are applied after the Height Attention operation to stabilize the training and enable the model to learn more effectively.\n3. **MLP (Multi - Layer Perceptron)**: This is a feed - forward neural network that further processes the output from the Height Attention module. It is used to introduce non - linearity and transform the features into a more discriminative representation.\n4. **Add&Norm**: Finally, another residual connection and layer normalization are applied after the MLP operation.\n\n### Output\nThe output of the Timesformer block is **Z(l)**, which is the processed feature map for the current layer. This output can be used as the input for the next layer in a deeper Timesformer architecture or can be further processed for tasks such as video classification.\n\nIn summary, the Timesformer block combines both temporal and spatial attention mechanisms to effectively process video data, making it suitable for a wide range of video - based tasks. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 33,
+                        "author": [
+                          "Yicheng Qiu",
+                          "Li Niu",
+                          "Feng Sha"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Counting repetitive actions is important in work and daily life. Automated counting using deep learning provides a more efficient, accurate alternative to manual counting, which is tedious and error-prone Deep-learning models have been proposed to automatically count repetitive actions in video content. However, for these models to be applied to realistic scenes, high-quality performance and generalization to multiple environments, particularly for long videos, are essential. To address these challenges, we propose a new model, ME-RAC, which includes the multipath 3D-Conv encoder module, and we also propose a temporal-sequence random-combination data augmentation to improve counting performance and prevent model over-fitting during training. Additionally, we propose the temporal-sequence-decision (TSD) framework system to realize long repetitive-action counting in complex realistic scenes. We conducted experiments to validate that our proposed methods perform better than comparable methods and our TSD framework achieved unique performance in long repetitive-action-counting tasks.",
+                        "abstractZh": "计算重复动作在工作和日常生活中很重要。使用深度学习的自动计数为手动计数提供了更高效、更准确的替代方案，手动计数既繁琐又容易出错。深度学习模型已被提出来自动计数视频内容中的重复动作。然而，为了将这些模型应用于现实场景，高质量的性能和对多种环境的泛化，特别是长视频，是至关重要的。为了应对这些挑战，我们提出了一种新模型 ME-RAC，其中包括多路径 3D-Conv 编码器模块，我们还提出了一种时间序列随机组合数据增强，以提高计数性能并防止训练期间模型过度拟合。此外，我们提出了时间序列决策（TSD）框架系统来实现复杂现实场景中的长时间重复动作计数。我们进行了实验来验证我们提出的方法比同类方法表现更好，并且我们的 TSD 框架在长时间重复动作计数任务中实现了独特的性能。",
+                        "title": "Multipath 3D-Conv encoder and temporal-sequence decision for repetitive-action counting",
+                        "titleZh": "用于重复动作计数的多径3D卷积编码器和时间序列决策",
+                        "doi": "10.1016/j.eswa.2024.123760",
+                        "bohriumId": "980291393429700637",
+                        "publicationId": 2452,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2452.png",
+                        "publicationDate": "2024-03-28",
+                        "journal": "Expert Systems with Applications",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.3188803844831095,
+                        "relevanceScore": 0.14414885640144348,
+                        "publicationScore": 0.8468292682926829,
+                        "impactFactor": 7.5,
+                        "impactFactorScore": 0.31512605042016806,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "980291393429700637_fig2_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/2452/980291393429700637/980291393429700637_fig2_1.png",
+                            "enExplain": "### 科学领域及具体研究方向\n这张图片属于计算机科学领域，具体研究方向为计算机视觉中的视频处理和深度学习模型架构设计。图中展示了一种结合卷积神经网络（CNN）和Transformer架构的视频处理模型结构。\n\n### 科学图片解析关注点\n1. **模型架构组成**：各组件的类型和名称。\n2. **操作流程**：数据在不同组件之间的流向和处理步骤。\n3. **组件参数**：如卷积层的核大小等参数设置。\n4. **组件之间的连接关系**：例如数据是如何在不同层之间传递和融合的。\n\n### 英文详细解析\n\nThe image depicts a neural - network architecture for video processing, integrating components from both convolutional neural networks (CNNs) and transformers.\n\n1. **Input and Initial Processing**\n   - The starting point is the \"Video Tensor\", which is the input to the model. This tensor represents the video data in a multi - dimensional format suitable for processing by the neural network.\n2. **Video Swin Transformer**\n   - Below the input video tensor is the \"Video Swin Transformer\" block. The Swin Transformer is a variant of the Transformer architecture designed specifically for handling visual data, in this case, video. It is responsible for capturing long - range dependencies and global information in the video frames.\n3. **Convolutional Layers**\n   - After the Video Swin Transformer, there are multiple \"Conv3d\" (3 - dimensional convolutional) layers.\n     - There are three \"Conv3d\" layers with a kernel size of $1\\times1\\times1$. These $1\\times1\\times1$ convolutions are often used for feature reduction or channel - wise operations. They can change the number of channels in the feature maps while keeping the spatial and temporal dimensions relatively intact.\n     - One \"Conv3d\" layer has a kernel size of $3\\times3\\times3$, and another has a kernel size of $5\\times5\\times5$. Larger kernel sizes like these can capture more spatial and temporal context in the video data. The $3\\times3\\times3$ and $5\\times5\\times5$ convolutions are likely used to extract more complex spatial - temporal features from the video.\n4. **Channel Concatenation and Output**\n   - The outputs from the different \"Conv3d\" layers are fed into a \"Channel Concatenation\" operation. This operation combines the feature maps from different convolutional layers along the channel dimension, effectively merging different types of features extracted by the various convolutional layers.\n   - Finally, the output of the channel concatenation is the \"Output\" of the overall model, which can be used for tasks such as video classification, action recognition, etc.\n\nIn summary, this architecture combines the strengths of the Swin Transformer for global feature extraction and 3 - D convolutional layers for local spatial - temporal feature extraction, and then merges the features through channel concatenation to produce the final output for video - related tasks. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 34,
+                        "author": [
+                          "Guoxiang Tong",
+                          "Zhaoyuan Ge",
+                          "Dunlu Peng"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Long sequence time-series forecasting (LSTF) is a significant and challenging task. Many real-world applications require long-term forecasting of time series. In recent years, Transformer-based models have emerged as a promising solution for addressing LSTF tasks. Nevertheless, the model’s performance is constrained by several issues, including the single time scale, the quadratic calculation complexity of the self-attention mechanism, and the high memory occupation. Based on the limitations mentioned above, we propose a novel approach in this paper, namely the multiscale residual sparse attention model RSMformer, built upon the Transformer architecture. Firstly, a residual sparse attention (RSA) mechanism is devised to select dominant queries for computation, utilizing the attention sparsity criterion. This approach effectively reduces the computational complexity to O$$\\varvec{\\mathcal {O}}$$(LlogL). Secondly, we employ a multiscale forecasting strategy to iteratively refine the accuracy of prediction results at multiple scales by utilizing up-and-down sampling techniques and cross-scale centralization schemes, which effectively capture the temporal dependencies at different time scales. Extensive experiments on six publicly available datasets show that RSMformer performs significantly better than the compared state-of-the-art benchmarks and excels in the LSTF tasks.",
+                        "abstractZh": "长序列时间序列预测（LSTF）是一项重要且具有挑战性的任务。许多现实世界的应用需要对时间序列进行长期预测。近年来，基于 Transformer 的模型已成为解决 LSTF 任务的有前途的解决方案。然而，该模型的性能受到时间尺度单一、自注意力机制的二次计算复杂度以及内存占用高等问题的制约。基于上述限制，我们在本文中提出了一种新方法，即基于 Transformer 架构的多尺度残差稀疏注意力模型 RSMformer。首先，设计了一种残余稀疏注意力（RSA）机制，利用注意力稀疏标准来选择主要查询进行计算。这种方法有效地将计算复杂度降低到 O$$\\varvec{\\mathcal {O}}$$(LlogL)。其次，我们采用多尺度预测策略，利用上下采样技术和跨尺度集中方案，迭代地细化多个尺度上的预测结果的准确性，从而有效地捕获不同时间尺度上的时间依赖性。对六个公开可用数据集的广泛实验表明，RSMformer 的性能明显优于所比较的最先进基准，并且在 LSTF 任务中表现出色。",
+                        "title": "RSMformer: an efficient multiscale transformer-based framework for long sequence time-series forecasting",
+                        "titleZh": "RSMformer：一种基于多尺度Transformer的高效长序列时间序列预测框架",
+                        "doi": "10.1007/s10489-023-05250-8",
+                        "bohriumId": "977543016153612399",
+                        "publicationId": 2510,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2510.png",
+                        "publicationDate": "2024-01-01",
+                        "journal": "Applied Intelligence",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "Multiscale processing methods find applications in a wide range of fields, including computer vision [32], natural language processing [33], and time series forecasting [34]. In the realm of computer vision, Multiscale Vision Transformers [35] have combined multiscale feature hierarchies with Transformer models for video and image recognition.However, their focus is primarily on the spatial domain and dedicated to computer vision tasks. In the domain of time series forecasting, MiRNN [36] employs a deep wavelet decomposition network to divide the original time series into different-scale sub-series.It jointly models temporal correlations within the sub-sequences and captures multiscale temporal dependencies using a two-stage attention mechanism. MAGNN [37] utilized a multiscale pyramidal network to preserve underlying temporal dependencies.Collaboration across time scales was effectively facilitated with the aid of a scale fusion module, allowing for the automatic capture of the importance of contributing temporal patterns. Nevertheless, these methods are not directly applicable to Transformer-based models.Preformer [38] proposed an efficient multiscale segmental correlation mechanism based on the Transformer approach. It segmented the time series and encoded it using attention based on segmental correlation.Although the multiscale structure summarized dependencies at different time scales, it is worth noting that its computational complexity is still O(L2)\\mathcal {O}(L^2).",
+                        "sortScore": 0.3068059371841081,
+                        "relevanceScore": 0.19559408724308014,
+                        "publicationScore": 0.8043902439024391,
+                        "impactFactor": 3.4,
+                        "impactFactorScore": 0.14285714285714285,
+                        "citationNums": 1,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 35,
+                        "author": [
+                          "Bubryur Kim",
+                          "Yuvaraj Natarajan",
+                          "K.R. Sri Preethaa",
+                          "Sujeen Song",
+                          "Jinwoo An",
+                          "Sanjeev Mohan"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Ensuring the structural integrity of civil infrastructures is critical, given the potential hazards presented by cracks. Traditional manual inspections, though common, often face challenges related to accuracy, accessibility, safety, and cost-effectiveness. To address these issues, this study presents a new approach that integrates unmanned aerial vehicles (UAVs) with advanced computer vision techniques. A key feature of our approach is a system where a self-operating UAV is paired with a carefully crafted deep-learning design. This design takes advantage of both the Fast Region-based Convolutional Neural Network (FRCNN) and Residual Network (ResNet) models, allowing for real-time and accurate crack detection from ongoing video feeds. For uninterrupted real-time processing, our UAV is equipped with a data transmission module, sending live video to a computational platform enhanced with our advanced crack-spotting tool. After thorough training using a diverse dataset of 1000 images, our FRCNN-ResNet model was compared to other top models, achieving a precision rate of 93.3% and a quick 59.7ms inference time. Overall, this study offers a notable improvement in how we monitor civil structures, focusing on better safety and cost savings.",
+                        "abstractZh": "鉴于裂缝带来的潜在危险，确保民用基础设施的结构完整性至关重要。传统的手动检查虽然很常见，但经常面临准确性、可访问性、安全性和成本效益方面的挑战。为了解决这些问题，本研究提出了一种将无人机 (UAV) 与先进计算机视觉技术相结合的新方法。我们方法的一个关键特征是一个将自主操作的无人机与精心设计的深度学习设计相结合的系统。该设计利用了基于快速区域的卷积神经网络 (FRCNN) 和残差网络 (ResNet) 模型，可以从持续的视频源中进行实时、准确的裂纹检测。为了实现不间断的实时处理，我们的无人机配备了数据传输模块，将实时视频发送到使用我们先进的裂纹发现工具增强的计算平台。在使用包含 1000 张图像的多样化数据集进行彻底训练后，我们的 FRCNN-ResNet 模型与其他顶级模型进行了比较，实现了 93.3% 的准确率和 59.7 毫秒的快速推理时间。总体而言，这项研究显着改进了我们监控土木结构的方式，重点关注更好的安全性和节省成本。",
+                        "title": "Real-time assessment of surface cracks in concrete structures using integrated deep neural networks with autonomous unmanned aerial vehicle",
+                        "titleZh": "使用集成深度神经网络与自主无人机对混凝土结构表面裂缝进行实时评估",
+                        "doi": "10.1016/j.engappai.2023.107537",
+                        "bohriumId": "937931084304220198",
+                        "publicationId": 2472,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2472.png",
+                        "publicationDate": "2023-12-01",
+                        "journal": "Engineering Applications of Artificial Intelligence",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.28949999598567955,
+                        "relevanceScore": 0.11436853557825089,
+                        "publicationScore": 0.7892682926829269,
+                        "impactFactor": 7.5,
+                        "impactFactorScore": 0.31512605042016806,
+                        "citationNums": 8,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "937931084304220198_fig1_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/2472/937931084304220198/937931084304220198_fig1_1.png",
+                            "enExplain": "This image illustrates a system for crack inspection using an Unmanned Aerial Vehicle (UAV). The system is divided into three main sections: UAV monitoring, ground station, and crack inspection.\n\n### UAV Monitoring Section\n- **UAV**: At the top - left of this section, there is an image of a quad - copter UAV. This UAV is used for structural monitoring. It is equipped to capture video footage of the structures under inspection.\n- **UAV Structural Monitoring**: Below the UAV image, there is a representation of the UAV's role in structural monitoring. The UAV is flying over a structure (depicted by a simple building - like shape with red - dotted lines), capturing relevant visual data.\n- **Video Transmitter**: At the bottom of this section, there is a symbol of a video transmitter. This device is likely responsible for sending the video data captured by the UAV to the ground station.\n\n### Ground Station Section\n- **Video Receiver Unit**: This unit is composed of two parts. The first part is a \"Video Receiver\" which is connected to a \"Telemetry receiver\". The video receiver is responsible for receiving the video signal from the UAV, and the telemetry receiver may receive other relevant data such as the UAV's position, orientation, etc.\n- **Computational Device**: Connected to a \"Com port\" (communication port), the computational device is the central processing unit on the ground station. It processes the received video data.\n- **DL Model Execution**: This sub - section is further divided into four components. \n  - **Tensor flow** and **DL libraries**: These are used for implementing deep - learning (DL) models. TensorFlow is an open - source machine - learning framework, and DL libraries provide the necessary functions and algorithms for deep - learning operations.\n  - **Open CV** and **Video inference**: OpenCV (Open Source Computer Vision Library) is used for computer - vision tasks. Video inference likely involves using the DL models and OpenCV to analyze the video data in real - time.\n\n### Crack Inspection Section\n- **Detection Generator**: This is the first step in the crack - inspection process. It generates initial detections in the video frames.\n- **Crack Classification**: Once detections are generated, this step classifies them into different types of cracks.\n- **Crack Recognition**: This step focuses on accurately recognizing the cracks based on the classified detections.\n- **Bounding Boxes**: Finally, bounding boxes are drawn around the recognized cracks in the video frames. The bottom of this section shows four example images with green bounding boxes around the cracks, demonstrating the output of the real - time crack - detection system.\n\nOverall, the system uses a UAV to capture video data, transmits it to a ground station for processing using deep - learning and computer - vision techniques, and then performs real - time crack detection and visualization. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 36,
+                        "author": [
+                          "Yingchao Xue",
+                          "Hongwei Ning",
+                          "Hui Jiang"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "In this study, a Raman spectral model trained based on Transformer-improved one-dimensional convolutional neural network (1D-CNN) was proposed for the quantitative analysis of zearalenone in wheat. Raman spectra of wheat flour samples with varying levels of mold contamination were acquired using a portable Raman spectrometer. The 1D-CNN was introduced to extract local features of Raman spectra using three convolutional layers, and then the Transformer module was employed to encode and decode these local features for obtaining global information. This approach ensured that the network could better learn complex input spectra data, thereby improving the detection accuracy and precision of the model. The results showed that the improved 1D-CNN model had better generalization performance compared to the 1D-CNN model, with a root mean square error of prediction (RMSEP) of 2.5759 μg/kg, a coefficient of determination ( RP2 ) of 0.9837, and a relative prediction deviation (RPD) of 7.9516. The study demonstrated that the 1D-CNN model improved by Transformer could achieve better feature self-learning and multivariate model correction of Raman spectroscopy data. This research introduces a novel reference method for chemometric analysis of Raman spectra.",
+                        "abstractZh": "本研究提出了一种基于 Transformer 改进的一维卷积神经网络（1D-CNN）训练的拉曼光谱模型，用于小麦中玉米赤霉烯酮的定量分析。使用便携式拉曼光谱仪获取具有不同霉菌污染水平的小麦面粉样品的拉曼光谱。引入 1D-CNN 使用三个卷积层提取拉曼光谱的局部特征，然后使用 Transformer 模块对这些局部特征进行编码和解码以获得全局信息。这种方法保证了网络能够更好地学习复杂的输入光谱数据，从而提高模型的检测精度和精度。结果表明，改进的1D-CNN模型相比1D-CNN模型具有更好的泛化性能，预测均方根误差（RMSEP）为2.5759 μg/kg，决定系数（RP2）为0.9837，相对预测偏差 (RPD) 为 7.9516。研究表明，经过Transformer改进的1D-CNN模型可以实现更好的拉曼光谱数据的特征自学习和多元模型校正。本研究介绍了一种用于拉曼光谱化学计量分析的新颖参考方法。",
+                        "title": "Determination of zearalenone content in wheat by modified one-dimensional convolutional neural network-based Raman spectra",
+                        "titleZh": "基于改进的一维卷积神经网络的拉曼光谱法测定小麦中玉米赤霉烯酮含量",
+                        "doi": "10.1016/j.sna.2024.115221",
+                        "bohriumId": "970864015586623510",
+                        "publicationId": 4064,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/4064.png",
+                        "publicationDate": "2024-03-02",
+                        "journal": "Sensors and Actuators A Physical",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "The Transformer made its first appearance in 2017 in a paper titled \"Attention is All You Need,\" published by the Google Machine Translation team [23]. It completely departed from traditional network structures such as RNNs and CNNs and solely employed the attention mechanism for machine translation tasks, achieving impressive results.In the field of Natural Language Processing (NLP), the Transformer has demonstrated remarkable performance. Subsequently, researchers extensively applied the Transformer to various tasks such as computer vision, speech recognition, object detection, and image and video processing, yielding promising results.Due to its outstanding performance, an increasing number of Transformer-based models are being utilized to enhance various tasks. Unlike traditional neural networks, the Transformer can directly capture global information without the need for step-by-step recursion.",
+                        "sortScore": 0.28777237008228174,
+                        "relevanceScore": 0.14414885640144348,
+                        "publicationScore": 0.8341463414634146,
+                        "impactFactor": 4.1,
+                        "impactFactorScore": 0.17226890756302518,
+                        "citationNums": 1,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 37,
+                        "author": [
+                          "Yunus Can Bilge",
+                          "Begum Mutlu",
+                          "Yunus Emre Esin"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "In the contemporary era, modern public buses are equipped with multiple built-in cameras, offering real-time or recorded monitoring capabilities through centralized systems. This research endeavors to introduce a novel approach for classifying driver behaviors at the signalized road intersections with traffic lights by leveraging a public bus vehicular camera that encompasses the road and thus traffic lights. The proposed method involves a 2-step multi-head self-attention network that employs the extracted traffic light state, and optic flow information besides the raw vehicular camera video. Subsequently, a bi-directional long short-term memory based spatio-temporal aggregation strategy is applied to guide the learning final discriminative representation. To evaluate the proposed approach, we introduce a benchmark dataset called BusEye , which covers the challenging real-life scenarios that are captured on actual vehicular cameras mounted on public busses. We provide extensive analysis and ablation studies on the BusEye dataset that shows our proposed solution outperforms the state-of-the-art video classification methods both on a per-class basis and overall. Based on the outcomes derived from the validation and test data, the proposed method demonstrated remarkable efficacy in classifying driver behaviors at signalized intersections.",
+                        "abstractZh": "在当代，现代公共巴士配备了多个内置摄像头，通过集中系统提供实时或记录的监控功能。本研究致力于引入一种新颖的方法，通过利用包围道路和交通灯的公共巴士车载摄像头，对带有交通灯的信号道路交叉口的驾驶员行为进行分类。所提出的方法涉及一个两步多头自注意力网络，该网络除了原始车辆摄像机视频之外还采用提取的交通灯状态和光流信息。随后，应用基于双向长短期记忆的时空聚合策略来指导学习最终的判别表示。为了评估所提出的方法，我们引入了一个名为 BusEye 的基准数据集，它涵盖了公共巴士上安装的实际车载摄像头捕获的具有挑战性的现实生活场景。我们对 BusEye 数据集进行了广泛的分析和消融研究，表明我们提出的解决方案在每个类别和整体上都优于最先进的视频分类方法。根据验证和测试数据得出的结果，所提出的方法在对信号交叉口的驾驶员行为进行分类方面表现出显着的功效。",
+                        "title": "BusEye: A multi-stream approach for driver behavior analysis on public bus driver cameras",
+                        "titleZh": "BusEye：一种基于公共汽车驾驶员摄像头的多流方法用于驾驶员行为分析",
+                        "doi": "10.1016/j.eswa.2024.123148",
+                        "bohriumId": "953120200885010439",
+                        "publicationId": 2452,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2452.png",
+                        "publicationDate": "2024-01-13",
+                        "journal": "Expert Systems with Applications",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.2839215860549165,
+                        "relevanceScore": 0.09807931631803513,
+                        "publicationScore": 0.8102439024390244,
+                        "impactFactor": 7.5,
+                        "impactFactorScore": 0.31512605042016806,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "953120200885010439_fig2_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/2452/953120200885010439/953120200885010439_fig2_1.png",
+                            "enExplain": "### 科学领域和具体研究方向\n这张图片属于计算机科学领域，具体研究方向是计算机视觉中的交通场景分析，尤其是交通信号灯状态的识别和相关视频特征处理。\n\n### 科学图片解析关注点\n1. **数据输入和预处理**：关注原始视频数据如何被输入系统以及进行了哪些初步处理。\n2. **目标检测模块**：关注如何从视频帧中检测出交通信号灯。\n3. **特征提取**：关注使用何种方法（如M_ViT）提取视频特征、信号灯特征和光流特征。\n4. **特征融合和处理**：关注不同类型的特征（视频特征、信号灯特征、光流特征）如何被融合以及进一步处理（如多头自注意力机制、bi - LSTM等）。\n5. **输出结果**：关注最终的输出结果是什么（如预测的交通信号灯状态）。\n\n### 图片解析\n\nThe diagram illustrates a system for analyzing traffic light states in video footage, which is a part of computer - vision research for traffic scene analysis.\n\n1. **Input and Initial Processing**\n   - The system starts with \"Raw video\", which is the input data. An \"Object Detection\" module is applied to the raw video frames. This module detects traffic lights in the video frames, as indicated by the red - bordered boxes highlighting the detected traffic lights in the sample video frames.\n2. **Feature Extraction**\n   - **Video Features**: The detected traffic - light regions and the overall video are processed by an \"M_ViT\" (presumably a modified Vision Transformer). Positional encoding is applied to the features before they are further processed. The output of this process is \"video features\", represented as a grid - like structure.\n   - **Light Features**: After object detection, the \"Light area\" is isolated. A \"Softmax\" operation is first applied, and then the data is processed by another \"M_ViT\" with positional encoding. The resulting \"weighted light features\" are then obtained.\n   - **Optical Flow Features**: \"Motion estimation\" is carried out on the raw video to generate an \"Optic flow\" pattern. This pattern is then processed by a \"Linear layer\" to obtain \"optical flow features\", represented as a grid - like structure similar to the other feature types.\n3. **Feature Fusion and Further Processing**\n   - The \"video features\", \"weighted light features\", and \"optical flow features\" are fed into a \"Multi - head self - attention\" module for feature fusion. After that, the fused features are processed by a \"bi - LSTM\" (bidirectional Long Short - Term Memory) network. There are also additional components like \"GRL\" (Gradient Reversal Layer) and \"<SRL>\" (presumably some form of special - purpose layer or operation), which are used to further process the data for the final output.\n4. **Output**\n   - The final output of the system is related to the \"Light state\", which means the system aims to predict the state (e.g., red, yellow, green) of the traffic lights in the input video. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 38,
+                        "author": [
+                          "Chen-Hsiu Huang",
+                          "Ja-Ling Wu"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "End-to-end learned image compression codecs have notably emerged in recent years. These codecs have demonstrated superiority over conventional methods, showcasing remarkable flexibility and adaptability across diverse data domains while supporting new distortion losses. Despite challenges such as computational complexity, learned image compression methods inherently align with learning-based data processing and analytic pipelines due to their well-suited internal representations. The concept of Video Coding for Machines has garnered significant attention from both academic researchers and industry practitioners. This concept reflects the growing need to integrate data compression with computer vision applications. In light of these developments, we present a comprehensive survey and review of lossy image compression methods. Additionally, we provide a concise overview of two prominent international standards, MPEG Video Coding for Machines and JPEG AI. These standards are designed to bridge the gap between data compression and computer vision, catering to practical industry use cases.",
+                        "abstractZh": "近年来，端到端学习的图像压缩编解码器显著涌现。这些编解码器已展现出优于传统方法的优势，在支持新的失真损失的同时，在不同数据领域展示出卓越的灵活性和适应性。尽管存在计算复杂度等挑战，但由于其内部表示非常合适，基于学习的图像压缩方法本质上与基于学习的数据处理和分析管道相契合。机器视频编码的概念已引起学术研究人员和行业从业者的广泛关注。这一概念反映了将数据压缩与计算机视觉应用集成的日益增长的需求。鉴于这些发展，我们对有损图像压缩方法进行了全面的调查和综述。此外，我们简要概述了两个著名的国际标准，即机器用MPEG视频编码和JPEG AI。这些标准旨在弥合数据压缩与计算机视觉之间的差距，以满足实际行业用例的需求。 ",
+                        "title": "Unveiling the Future of Human and Machine Coding: A Survey of End-to-End Learned Image Compression",
+                        "titleZh": "揭示人类与机器编码的未来：端到端学习图像压缩综述",
+                        "doi": "10.3390/e26050357",
+                        "bohriumId": "990432382291017742",
+                        "publicationId": 619,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/619.png",
+                        "publicationDate": "2024-04-25",
+                        "journal": "Entropy",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.28340757078445866,
+                        "relevanceScore": 0.1561049073934555,
+                        "publicationScore": 0.8604878048780488,
+                        "impactFactor": 2.1,
+                        "impactFactorScore": 0.08823529411764706,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "990432382291017742_fig20_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/619/990432382291017742/990432382291017742_fig20_1.png",
+                            "enExplain": "### Overall Structure\nThe diagram illustrates a system for video - related processing, which consists of two main components: a VCM Encoder and a VCM Decoder, connected by a bitstream transmission link. The system aims to handle sensor output, encoding it for transmission and then decoding it for different applications such as human and machine vision.\n\n### VCM Encoder\n1. **Input**: The \"Sensor output\" serves as the starting point for the encoding process. This is the raw data captured by a sensor, which could be a camera sensor providing video - related information.\n2. **Video Encoding**: One of the two parallel processes in the VCM Encoder is \"Video Encoding\". This step compresses the video data from the sensor output into a more transmission - friendly format. The goal is to reduce the amount of data while maintaining the essential visual information.\n3. **Feature Extraction and Encoding**: In parallel to video encoding, there is a \"Feature extraction\" module. This module analyzes the sensor output to identify important features. These features could be related to objects, motion, or other significant elements in the video. After feature extraction, the \"Feature encoding\" step encodes these extracted features into a digital representation suitable for transmission.\n4. **NN Interface**: There is an \"NN interface\" (presumably a neural - network interface) associated with the feature extraction and encoding processes. This interface may be used to interact with a neural network for more advanced feature extraction or encoding tasks, such as using deep - learning models to identify complex visual features.\n5. **Muxer**: After the video encoding and feature encoding processes are completed, the \"Muxer\" combines the encoded video data and the encoded feature data into a single bitstream. This bitstream is then ready for transmission.\n\n### Bitstream Transmission\nThe bitstream generated by the muxer in the VCM Encoder is sent through a \"Bitstream transmission\" link. This could be a wired or wireless communication channel, depending on the application requirements.\n\n### VCM Decoder\n1. **Demuxer**: At the receiving end, the \"Demuxer\" in the VCM Decoder splits the received bitstream back into the encoded video data and the encoded feature data.\n2. **Video Encoding (Decoder Side)**: The \"Video Encoding\" module in the decoder side (which is likely a mis - label and should be \"Video Decoding\") decodes the received encoded video data back into a format that can be used for display or further processing. This step restores the video to a form that can be presented to human vision.\n3. **Feature Extraction (Decoder Side)**: The \"Feature extraction\" module in the decoder side extracts the features from the received encoded feature data. These features are then used for machine vision applications.\n4. **Human Vision and Machine Vision**: The decoded video data is directed to the \"Human Vision\" output, which could be a display device for a human operator to view the video. The extracted features are sent to the \"Machine Vision\" output, where they can be used by computer - based vision systems for tasks such as object recognition, motion analysis, etc.\n5. **NN Interface**: Similar to the encoder, the decoder also has an \"NN interface\" associated with the feature extraction process. This interface can be used to interact with a neural network for more advanced feature - based machine vision tasks. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 39,
+                        "author": [
+                          "Toufik Benmessabih",
+                          "Rim Slama",
+                          "Vincent Havard",
+                          "David Baudry"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Human motion analysis plays a crucial role in industry 4.0 and, more recently, in industry 5.0 where human-centered applications are becoming increasingly important, demonstrating its potential for enhancing safety, ergonomics and productivity. Considering this opportunity, an increasing number of studies are proposing works on the analysis of human motion in an industrial context, taking advantage of the rise of artificial intelligence technologies and sensor technologies. The objective of this work is to provide a review of recent studies exploring these technologies in the analysis of human movement while specifically considering industrial context. First, a taxonomy of key human motion analysis applications is proposed, presenting statistical insights to reveal trends and highlighting lacks in current research. Furthermore, this work identifies benchmark datasets acquired in various industrial case studies and associated sensors. Many recommendations for selecting optimal sensors and valuable benchmarks are proposed. Then, the paper outlines the current trend of utilizing hybrid deep learning methodologies in human movement analysis while underscoring the performance and limitations of these proposed methods, considering industrial constraints such as real-time recognition and frugality. Finally, challenges and future works are highlighted, focusing on the opportunities to address problems related to the complex industrial environment in order to achieve reliable performances.",
+                        "abstractZh": "人体运动分析在工业 4.0 和最近的工业 5.0 中发挥着至关重要的作用，在工业 5.0 中，以人为本的应用变得越来越重要，展示了其在增强安全性、人体工程学和生产力方面的潜力。考虑到这一机遇，越来越多的研究提出利用人工智能技术和传感器技术的兴起，在工业背景下分析人体运动。这项工作的目的是回顾最近在人类运动分析中探索这些技术的研究，同时特别考虑工业背景。首先，提出了关键人体运动分析应用的分类，提供统计见解以揭示趋势并强调当前研究的不足。此外，这项工作还确定了在各种工业案例研究和相关传感器中获取的基准数据集。提出了许多关于选择最佳传感器和有价值的基准的建议。然后，本文概述了在人体运动分析中利用混合深度学习方法的当前趋势，同时强调了这些方法的性能和局限性，并考虑了实时识别和节俭等工业限制。最后，强调了挑战和未来的工作，重点关注解决与复杂工业环境相关的问题以实现可靠性能的机会。",
+                        "title": "Online human motion analysis in industrial context: A review",
+                        "titleZh": "工业环境中的在线人体运动分析：综述",
+                        "doi": "10.1016/j.engappai.2024.107850",
+                        "bohriumId": "953478135456727052",
+                        "publicationId": 2472,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2472.png",
+                        "publicationDate": "2024-01-14",
+                        "journal": "Engineering Applications of Artificial Intelligence",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.26689660349346755,
+                        "relevanceScore": 0.06954174488782883,
+                        "publicationScore": 0.8107317073170732,
+                        "impactFactor": 7.5,
+                        "impactFactorScore": 0.31512605042016806,
+                        "citationNums": 4,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "953478135456727052_fig11_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/2472/953478135456727052/953478135456727052_fig11_1.png",
+                            "enExplain": "This is a flowchart depicting a video - processing neural network architecture.\n\n### Input Video\nThe process starts with an \"Input Video\" on the left - hand side of the diagram. The input video is represented by a stack of blue rectangles, which symbolize video frames. These frames are the raw data that the system will process to extract meaningful information.\n\n### CNN (Convolutional Neural Network)\nNext, the input video frames are fed into a \"CNN\" module. This is represented by a stack of green rectangles. CNNs are powerful in extracting local spatial features from the video frames. They use convolutional layers to detect various patterns such as edges, textures, and simple objects within the frames. By doing so, they transform the raw video data into a more feature - rich representation.\n\n### Transformer\nAfter the CNN, the output is passed to a \"Transformer\" module. The Transformer has sub - components labeled \"MSA Attention Block\". The Transformer is designed to capture long - range dependencies and global relationships between different parts of the video. The MSA (Multi - Head Self - Attention) Attention Block allows the model to weigh the importance of different features at different positions in the video sequence, enabling it to understand complex temporal and spatial relationships.\n\n### Fully Connected\nThe output from the Transformer is then connected to a \"Fully Connected\" layer. This layer is represented by a set of blue circles. In a fully - connected layer, every neuron in the previous layer is connected to every neuron in this layer. It aggregates the features extracted by the previous layers and maps them to a more suitable representation for the final task.\n\n### Output\nFinally, the output of the fully - connected layer is passed to the \"Output\" section, which is represented by a set of red circles labeled \"0\", \"1\", and \"n\". These outputs can be used for various tasks such as classifying the video into different categories (e.g., action recognition in a video, where \"0\", \"1\",..., \"n\" represent different action classes).\n\nOverall, this architecture combines the strengths of CNNs for local feature extraction and Transformers for capturing long - range dependencies to process input videos and generate meaningful outputs for tasks like video classification. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 40,
+                        "author": [
+                          "Qingguo Zhou",
+                          "Yufeng Hou",
+                          "Rui Zhou",
+                          "Yan Li",
+                          "JinQiang Wang",
+                          "Zhen Wu",
+                          "Hung-Wei Li",
+                          "Tien-Hsiung Weng"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "The canonical video action recognition methods usually label categories with numbers or one-hot vectors and train neural networks to classify a fixed set of predefined categories, thereby constraining their ability to recognise complex actions and transferable ability to unseen concepts. In contrast, cross-modal learning can improve the performance of individual modalities. Based on the facts that a better action recogniser can be built by reading the statements used to describe actions, we exploited the recent multimodal foundation model CLIP for action recognition. In this study, an effective Vision-Language action recognition adaptation was implemented based on few-shot examples spanning different modalities. We added semantic information to action categories by treating textual and visual label as training examples for action classifier construction rather than simply labelling them with numbers. Due to the different importance of words in text and video frames, simply averaging all sequential features may result in ignoring keywords or key video frames. To capture sequential and hierarchical representation, a weighted token-wise interaction mechanism was employed to exploit the pair-wise correlations adaptively. Extensive experiments with public datasets show that cross-modal action recognition learning helps for downstream action images classification, in other words, the proposed method can train better action classifiers by reading the sentences describing action itself. The method proposed in this study not only reaches good generalisation and zero-shot/few-shot transfer ability on Out of Distribution (OOD) test sets, but also performs lower computational complexity due to the lightweight interaction mechanism with 84.15% Top-1 accuracy on the Kinetics-400.",
+                        "abstractZh": "传统的视频动作识别方法通常用数字或独热向量对类别进行标注，并训练神经网络对一组固定的预定义类别进行分类，从而限制了它们识别复杂动作的能力以及对未见概念的迁移能力。相比之下，跨模态学习可以提高单个模态的性能。基于通过读取用于描述动作的语句可以构建更好的动作识别器这一事实，我们利用最近的多模态基础模型CLIP进行动作识别。在本研究中，基于跨越不同模态的少样本示例实现了一种有效的视觉-语言动作识别适配。我们通过将文本和视觉标签作为动作分类器构建的训练示例，而不是简单地用数字对它们进行标注，从而为动作类别添加语义信息。由于文本和视频帧中单词的重要性不同，简单地对所有序列特征求平均可能会导致忽略关键词或关键视频帧。为了捕捉序列和层次表示，采用了一种加权的逐令牌交互机制来自适应地利用成对相关性。对公共数据集进行的大量实验表明，跨模态动作识别学习有助于下游动作图像分类，换句话说，所提出的方法可以通过读取描述动作本身的句子来训练更好的动作分类器。本研究中提出的方法不仅在分布外（OOD）测试集上具有良好的泛化能力和零样本/少样本迁移能力，而且由于其轻量级交互机制，计算复杂度较低，在Kinetics-400数据集上的Top-1准确率达到84.15%。 ",
+                        "title": "Cross-modal learning with multi-modal model for video action recognition based on adaptive weight training",
+                        "titleZh": "基于自适应权重训练的视频动作识别多模态模型跨模态学习",
+                        "doi": "10.1080/09540091.2024.2325474",
+                        "bohriumId": "980654269927522394",
+                        "publicationId": 2683,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2683.png",
+                        "publicationDate": "2024-03-29",
+                        "journal": "Connection Science",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "Building on the natural language processing breakthroughs, Transformer (Vaswani et al., 2017) has found tremendous success in computer vision scenarios. Transformer-based networks for video classification modify the Vision Transformer(ViT) to spatial and temporal features jointly, having better performance on several datasets.Yet, most prior models are unimodal without natural language supervision, which lack zero-shot transfer capability. Unlike most prior approaches, we study on vision-text multi-modality learning and extend work to zero-shot/few-shot video action recognition.The proposed approach mainly designs appropriate prompting methods which finetune CLIP-based frameworks by giving each class semantic information and inserting lightweight MLPs. Our model can offer richer semantics, enabling it to learn a wider range of feature representations.",
+                        "sortScore": 0.26309889596047475,
+                        "relevanceScore": 0.11124119907617569,
+                        "publicationScore": 0.8473170731707317,
+                        "impactFactor": 3.2,
+                        "impactFactorScore": 0.13445378151260504,
+                        "citationNums": 0,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 41,
+                        "author": [
+                          "Yukuan Zhang",
+                          "Housheng Xie",
+                          "Yunhua Jia",
+                          "Jingrui Meng",
+                          "Meng Sang",
+                          "Junhui Qiu",
+                          "Shan Zhao",
+                          "Yang Yang"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Information perception is crucial in MOT tasks. Recent approaches use positional, motion, and appearance information to model object states. However, in scenes involving camera motion, tracking tasks suffer from image distortion, trajectory loss, and mismatching issues. In this paper, we propose Adaptive Information Perception for Online Multi-Object Tracking, abbreviated as AIPT. AIPT consists of an Adaptive Motion Perception Module (AMPM) and an Asymmetric Information Suppression Module (AISM). In AMPM, we design an Adaptive Image Distortion Recovery Module (AIDRM) to perceive distortions in unknown scenes, allowing the tracker to autonomously recover distorted images as the scene changes. By designing the Information-Guided Trajectory Restoration Module (IGTRM), the tracker learns object motion states from prior information and constructs accurate reconstruction information during trajectory loss. Furthermore, our AISM module utilizes masking information to suppress potential relationships between asymmetric objects, thereby enhancing the ability of tracker to handle mismatches. Both AMPM and AISM exhibit excellent scalability, seamlessly integrating with most advanced tracking methods. Ultimately, our AIPT achieves leading performance on multiple benchmark platforms, including MOT17, MOT20, and KITTI.",
+                        "abstractZh": "信息感知在多目标跟踪（MOT）任务中至关重要。最近的方法使用位置、运动和外观信息来对目标状态进行建模。然而，在涉及相机运动的场景中，跟踪任务会受到图像失真、轨迹丢失和匹配问题的困扰。在本文中，我们提出了用于在线多目标跟踪的自适应信息感知（Adaptive Information Perception for Online Multi-Object Tracking，简称为AIPT）。AIPT由自适应运动感知模块（Adaptive Motion Perception Module，AMPM）和非对称信息抑制模块（Asymmetric Information Suppression Module，AISM）组成。在AMPM中，我们设计了一个自适应图像失真恢复模块（Adaptive Image Distortion Recovery Module，AIDRM）来感知未知场景中的失真，使跟踪器能够随着场景变化自主恢复失真图像。通过设计信息引导轨迹恢复模块（Information-Guided Trajectory Restoration Module，IGTRM），跟踪器从先验信息中学习目标运动状态，并在轨迹丢失期间构建准确的重建信息。此外，我们的AISM模块利用掩码信息来抑制非对称目标之间的潜在关系，从而增强跟踪器处理匹配问题的能力。AMPM和AISM都具有出色的可扩展性，能够与大多数先进的跟踪方法无缝集成。最终，我们的AIPT在多个基准平台上取得了领先性能，包括MOT17、MOT20和KITTI。 ",
+                        "title": "AIPT: Adaptive information perception for online multi-object tracking",
+                        "titleZh": "AIPT：用于在线多目标跟踪的自适应信息感知",
+                        "doi": "10.1016/j.knosys.2024.111369",
+                        "bohriumId": "952757365894021122",
+                        "publicationId": 2446,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2446.png",
+                        "publicationDate": "2024-01-12",
+                        "journal": "Knowledge-Based Systems",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.25850741752220574,
+                        "relevanceScore": 0.060086652636528015,
+                        "publicationScore": 0.8097560975609757,
+                        "impactFactor": 7.2,
+                        "impactFactorScore": 0.3025210084033613,
+                        "citationNums": 1,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "952757365894021122_fig5_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/2446/952757365894021122/952757365894021122_fig5_1.png",
+                            "enExplain": "The provided image illustrates a process likely related to computer - vision techniques for video processing, specifically dealing with frame - to - frame analysis.\n\n### 1. Frames and their properties\n- **Frames in general**: The image shows multiple frames of what appears to be a street - scene video. Each frame is a still image within the video sequence. The notation \"Frame #1\" and \"Frame #T\" are used to identify different frames. Here, \"T\" is likely a specific frame in the sequence that is of particular interest for further processing.\n- **Frame dimensions**: Each frame is described as having dimensions \\(H\\times W\\times3\\). In computer - vision, \\(H\\) represents the height of the frame in pixels, \\(W\\) represents the width of the frame in pixels, and the \"3\" indicates that the frame is in a color format, likely representing the red, green, and blue (RGB) color channels.\n\n### 2. Supporting Frame and Reference Frame\n- **Supporting Frame (Frame #1)**: This frame is one of the starting points for the processing pipeline. It has the dimensions \\(H\\times W\\times3\\) and is used as a basis for further analysis. It may provide some context or features that are used to understand the motion and changes in subsequent frames.\n- **Reference Frame (Frame #T)**: This frame also has the dimensions \\(H\\times W\\times3\\) and serves as a reference point for comparison. It is likely used to analyze the differences and similarities with other frames in the sequence, such as the supporting frame.\n\n### 3. Processing steps\n- **Corner detection**: The first processing step shown in the image is corner detection. This is applied to the supporting frame. Corner detection is a feature - extraction technique in computer vision that identifies points in an image where there are significant changes in intensity in multiple directions. In the context of video processing, these corner points can be used as feature points for tracking and motion analysis. The result of corner detection is shown as highlighted points in the top - right frame, which is the same as the supporting frame but with detected corners marked.\n- **Optical flow tracking**: The second processing step is optical flow tracking. This step takes the reference frame and uses the results from the corner detection (or other feature - extraction methods) to track the motion of features between the reference frame and another frame (presumably the supporting frame or a related frame). Optical flow is a technique that calculates the apparent motion of objects, surfaces, and edges in a visual scene caused by the motion of the observer and/or the objects in the scene. The result of optical flow tracking is shown in the bottom - right frame, where the motion of features is represented by arrows or vectors.\n\n### 4. The output \\(G\\)\n- The output \\(G\\) is not explicitly defined in the image, but it is likely a result of the combined operations of corner detection and optical flow tracking. It could represent a set of tracked features, a motion model, or some other relevant information derived from the analysis of the frames. For example, it could be a matrix or a set of data that describes the motion of objects in the video sequence between the reference frame and the supporting frame.\n\nIn summary, the image depicts a multi - step process in computer vision for analyzing video frames. It starts with feature extraction (corner detection) on a supporting frame and then uses optical flow tracking to analyze the motion between the reference frame and other frames, ultimately producing an output \\(G\\) that represents the results of this analysis. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 42,
+                        "author": [
+                          "Asif Mehmood",
+                          "Javeria Amin",
+                          "Muhammad Sharif",
+                          "Seifedine Kadry"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Human Gait Recognition (HGR) is referred to as a biometric tactic that is broadly used for the recognition of an individual by using the pattern of walking. There are some key factors such as angle variation, clothing variation, foot shadows, and carrying conditions that affect the human gait. In this work, a new approach is proposed for the HGR that contains five major steps. In the first step, the video data is converted into image frames. In the second step, RGB to GRAY conversion is carried out. After that, a two-stream network is designed by using a 55-layer CNN model called CNN-55 trained on CIFAR-100. The CNN-55 is designed from scratch and trained on the CIFAR-100 dataset by selecting hyperparameters. This pre-trained CNN-55 is used to build a two-stream network. In Stream-1 the optical flow frames are obtained by Horn and Schunk algorithm. These frames are fed into a CNN-55 to extract temporal features. In Stream-2 the GRAY frames are fed to the CNN-55 model for extraction of spatial features. After that, both vectors are serially fused. In the fourth step, the fused feature vector is fed into the Genetic Algorithm for optimization. Finally, the feature vector is fed into the One-Versus-All SVM classifier for recognition. The system is tested on all CASIA-B angles such as 00 0 , 18 0 , 36 0 , 54 0 , 72 0 , 90 0 , 108 0 , 126 0 , 144 0 , 162 0 , and 180 0 which provides accuracy of 97.10%, 96.80%, 94.60%, 98.0%, 98.30%, 96.80%, 97.60, 96.90%, 99.60%, 96.80%, and 97.60%, respectively. The proposed method produces better outcomes compared to recent techniques.",
+                        "abstractZh": "人体步态识别（HGR）是一种生物识别策略，广泛用于通过行走模式识别个体。存在一些关键因素，如角度变化、服装变化、脚部阴影和携带情况，会影响人体步态。在这项工作中，针对人体步态识别提出了一种新方法，该方法包含五个主要步骤。第一步，将视频数据转换为图像帧。第二步，进行RGB到灰度的转换。之后，使用在CIFAR-100上训练的名为CNN-55的55层卷积神经网络（CNN）模型设计双流网络。CNN-55是从零开始设计的，并通过选择超参数在CIFAR-100数据集上进行训练。这个预训练的CNN-55用于构建双流网络。在流1中，通过Horn和Schunk算法获得光流帧。这些帧被输入到CNN-55中以提取时间特征。在流2中，灰度帧被输入到CNN-55模型中以提取空间特征。之后，将两个向量进行串行融合。在第四步，将融合后的特征向量输入到遗传算法中进行优化。最后，将特征向量输入到一对多支持向量机（SVM）分类器中进行识别。该系统在所有CASIA-B角度上进行了测试，如0°、18°、36°、54°、72°、90°、108°、126°、144°、162°和180°，相应的准确率分别为97.10%、96.80%、94.60%、98.0%、98.30%、96.80%、97.60%、96.90%、99.60%、96.80%和97.60%。与最近的技术相比，所提出的方法产生了更好的结果。 ",
+                        "title": "Human Gait Recognition by using Two Stream Neural Network along with Spatial and Temporal Features",
+                        "titleZh": "基于双流神经网络结合空间和时间特征的人体步态识别",
+                        "doi": "10.1016/j.patrec.2024.02.010",
+                        "bohriumId": "964342161396989958",
+                        "publicationId": 2594,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2594.png",
+                        "publicationDate": "2024-02-13",
+                        "journal": "Pattern Recognition Letters",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.2526755502795133,
+                        "relevanceScore": 0.09138210862874985,
+                        "publicationScore": 0.8253658536585365,
+                        "impactFactor": 3.9,
+                        "impactFactorScore": 0.1638655462184874,
+                        "citationNums": 1,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "964342161396989958_fig4_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/2594/964342161396989958/964342161396989958_fig4_1.png",
+                            "enExplain": "This image illustrates a sequence of steps in a video - processing pipeline for extracting spatial features.\n\n### 1. Video to Frames\nThe first step is to convert a video into a frames sequence. The left - most part of the image shows a video represented as a stack of frames. A video is essentially a continuous stream of images, and by splitting it into individual frames, we can process each image separately. This is indicated by the \"Video to Frames\" arrow pointing from the video representation to the \"Frames Sequence\" box. The \"Frames Sequence\" box shows a single frame from the video, which in this case depicts an indoor scene with a person standing in the middle of a room and some furniture or objects in the background.\n\n### 2. RGB to Gray\nThe next step is to convert the color (RGB - Red, Green, Blue) frames into grayscale frames. This conversion is often done because grayscale images can simplify many computer - vision algorithms and reduce computational complexity while still retaining important visual information. The \"RGB to Gray\" arrow points from the color frame in the \"Frames Sequence\" box to the grayscale frame in the \"Gray Frames\" box. The grayscale frame has a monochromatic appearance, where different shades of gray represent the intensity of light in the original color image.\n\n### 3. Spatial Features\nThe final step in this pipeline is to extract spatial features from the grayscale frames. Spatial features are characteristics of the image that describe the spatial arrangement of objects, edges, textures, etc. The \"Spatial Features\" box on the right - most side of the image shows a heat - map or a representation of these features. This could be a result of applying algorithms such as edge detection, texture analysis, or other feature - extraction techniques on the grayscale frames. These spatial features can be used for various applications like object recognition, motion analysis, and scene understanding in computer - vision systems.\n\nOverall, this image provides a high - level overview of a common pre - processing and feature - extraction workflow for video data in computer - vision applications. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 43,
+                        "author": [
+                          "Dashuai Wang",
+                          "Zhuolin Li",
+                          "Xiaoqiang Du",
+                          "Zenghong Ma",
+                          "Xiaoguang Liu"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "In precision agriculture, unmanned aerial vehicles (UAVs) are playing an increasingly important role in farmland information acquisition and fine management. However, discrete obstacles in the farmland environment, such as trees and power lines, pose serious threats to the flight safety of UAVs. Real-time detection of the attributes of obstacles is urgently needed to ensure their flight safety. In the wake of rapid development of deep learning, object detection algorithms based on convolutional neural networks (CNN) and transformer architectures have achieved remarkable results. Detection Transformer (DETR) and Deformable DETR combine CNN and transformer to achieve end-to-end object detection. The goal of this work is to use Deformable DETR for the task of farmland obstacle detection from the perspective of UAVs. However, limited by local receptive fields and local self-attention mechanisms, Deformable DETR lacks the ability to capture long-range dependencies to some extent. Inspired by non-local neural networks, we introduce the global modeling capability to the front-end ResNet to further improve the overall performance of Deformable DETR. We refer to the improved version as Non-local Deformable DETR. We evaluate the performance of Non-local Deformable DETR for farmland obstacle detection through comparative experiments on our proposed dataset. The results show that, compared with the original Deformable DETR network, the mAP value of the Non-local Deformable DETR is increased from 71.3% to 78.0%. Additionally, Non-local Deformable DETR also presents great performance for detecting small and slender objects. We hope this work can provide a solution to the flight safety problems encountered by UAVs in unstructured farmland environments.",
+                        "abstractZh": "在精准农业中，无人机（UAV）在农田信息采集和精细管理方面发挥着越来越重要的作用。然而，农田环境中的离散障碍物，如树木和电线，对无人机的飞行安全构成了严重威胁。迫切需要实时检测障碍物的属性以确保其飞行安全。随着深度学习的快速发展，基于卷积神经网络（CNN）和Transformer架构的目标检测算法取得了显著成果。检测Transformer（DETR）和可变形DETR将CNN和Transformer相结合，实现了端到端的目标检测。这项工作的目标是从无人机的角度使用可变形DETR来完成农田障碍物检测任务。然而，受限于局部感受野和局部自注意力机制，可变形DETR在一定程度上缺乏捕捉长距离依赖关系的能力。受非局部神经网络的启发，我们将全局建模能力引入到前端ResNet中，以进一步提高可变形DETR的整体性能。我们将改进后的版本称为非局部可变形DETR。我们通过在我们提出的数据集上进行对比实验，评估了非局部可变形DETR在农田障碍物检测方面的性能。结果表明，与原始的可变形DETR网络相比，非局部可变形DETR的平均精度均值（mAP）值从71.3%提高到了78.0%。此外，非局部可变形DETR在检测小而细长的物体方面也表现出色。我们希望这项工作能够为无人机在非结构化农田环境中遇到的飞行安全问题提供一个解决方案。 ",
+                        "title": "Agriculture, Vol. 12, Pages 1983: Farmland Obstacle Detection from the Perspective of UAVs Based on Non-local Deformable DETR",
+                        "titleZh": "《农业》第12卷，第1983页：基于非局部可变形DETR的无人机视角下农田障碍物检测",
+                        "doi": "10.3390/agriculture12121983",
+                        "bohriumId": "817342301532585984",
+                        "publicationId": 96453,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/96453.png",
+                        "publicationDate": "2022-11-24",
+                        "journal": "Agriculture (Switzerland)",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "Transformer that exclusively rely on the self-attention mechanism to capture global dependencies has achieved remarkable success in natural language processing (NLP) [32]. Recently, many pioneering works have demonstrated that transformer architecture and its variants can also handle downstream computer vision tasks, such as image recognition: Vision Transformer (ViT [33]), Data-efficient image Transformers (DeiT [34]), Tokens-To-Token Vision Transformer (T2T [35]), Transformer in Transformer (TNT [36]), Conditional Positional encoding Vision Transformer (CPVT [37]), Shifted Windows Transformer (Swin Transformer [38]), object detection: Detection Transformer (DETR [39]), Deformable DETR [40], Swin Transformer, image segmentation: SEgmentation Transformer (SETR [41]), Pyramid Vision Transformer (PVT [42]), Transformer for semantic segmentation (Segmenter [43]), Swin Transformer, and video object tracking: Swin Transformer Tracker (SwinTrack [44]), Video Vision Transformer (ViViT [45]), Video Transformer (VidTr [46]) and Transformer Tracking (TransT [47]).",
+                        "sortScore": 0.24131250235847793,
+                        "relevanceScore": 0.12168574333190918,
+                        "publicationScore": 0.6078048780487805,
+                        "impactFactor": 0,
+                        "impactFactorScore": 0.23370037670240518,
+                        "citationNums": 4,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 44,
+                        "author": [
+                          "Md. Haidar Sharif",
+                          "Lei Jiao",
+                          "Christian W. Omlin"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Abnormal event detection is one of the most challenging tasks in computer vision. Many existing deep anomaly detection models are based on reconstruction errors, where the training phase is performed using only videos of normal events and the model is then capable to estimate frame-level scores for an unknown input. It is assumed that the reconstruction error gap between frames of normal and abnormal scores is high for abnormal events during the testing phase. Yet, this assumption may not always hold due to superior capacity and generalization of deep neural networks. In this paper, we design a generalized framework (rpNet) for proposing a series of deep models by fusing several options of a reconstruction network (rNet) and a prediction network (pNet) to detect anomaly in videos efficiently. In the rNet, either a convolutional autoencoder (ConvAE) or a skip connected ConvAE (AEc) can be used, whereas in the pNet, either a traditional U-Net, a non-local block U-Net, or an attention block U-Net (aUnet) can be applied. The fusion of both rNet and pNet increases the error gap. Our deep models have distinct degree of feature extraction capabilities. One of our models (AEcaUnet) consists of an AEc with our proposed aUnet has capability to confirm better error gap and to extract high quality of features needed for video anomaly detection. Experimental results on UCSD-Ped1, UCSD-Ped2, CUHK-Avenue, ShanghaiTech-Campus, and UMN datasets with rigorous statistical analysis show the effectiveness of our models.",
+                        "abstractZh": "异常事件检测是计算机视觉中最具挑战性的任务之一。许多现有的深度异常检测模型基于重建误差，其中训练阶段仅使用正常事件的视频进行，然后该模型能够为未知输入估计帧级分数。假设在测试阶段，异常事件的正常分数帧与异常分数帧之间的重建误差差距很大。然而，由于深度神经网络的强大能力和泛化性，这一假设并不总是成立。在本文中，我们设计了一个通用框架（rpNet），通过融合重建网络（rNet）和预测网络（pNet）的多种选项来提出一系列深度模型，以有效地检测视频中的异常。在rNet中，可以使用卷积自动编码器（ConvAE）或跳跃连接卷积自动编码器（AEc），而在pNet中，可以应用传统的U-Net、非局部块U-Net或注意力块U-Net（aUnet）。rNet和pNet的融合增加了误差差距。我们的深度模型具有不同程度的特征提取能力。我们的一个模型（AEcaUnet）由一个AEc和我们提出的aUnet组成，能够确认更好的误差差距，并提取视频异常检测所需的高质量特征。在UCSD-Ped1、UCSD-Ped2、CUHK-Avenue、上海科技大学校园和UMN数据集上进行的严格统计分析实验结果表明了我们模型的有效性。 ",
+                        "title": "Deep Crowd Anomaly Detection by Fusing Reconstruction and Prediction Networks",
+                        "titleZh": "通过融合重构与预测网络进行深度人群异常检测",
+                        "doi": "10.3390/electronics12071517",
+                        "bohriumId": "849055204459413504",
+                        "publicationId": 4412,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/4412.png",
+                        "publicationDate": "2023-03-24",
+                        "journal": "Electronics",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "Fundamentally, our rpNet is a natural extension of video classification-based on CNNs. Recently, it is demonstrated by evidence that a pure transformer-based architecture can outperform its convolutional counterparts in image classification [142].The transformer does not process the input in order, sequentially, but in parallel. For each element, the transformer integrates information from the other elements via self-attention.It can better capture long range contextual relationships in video. The vision transformer (ViT) is a successful application of a transformer in computer vision.In future, we wish to augment our generalized architecture by incorporating the ViT technologies with extracting spatiotemporal tokens from the input video, which would be then encoded by a series of the ViT layers. Moreover, we used Sigmoid activation function where the output is guaranteed between 0 and 1, but Sigmoid activation is tough.Nevertheless, ViT does not need any Sigmoid or Tanh activation. The ViT performs very favorably over CNNs only if the dataset for pretraining is sufficiently large [143].For example, an experimental setup of Dosovitskiy et al.[143] claimed that under 100 million images the accuracy of the variants of ResNet [60] (e.g., ResNet50x1 (BiT) and ResNet152x2 (BiT)) was better than that of the ViT.Yet, the accuracy of those variants did not improve as the number of samples grew from 100 million images to 300 million images. Conversely, the ViT performed positively and hence it outperformed all of its convolutional counterparts considering 300 million images [143].In short, the bigger the datasets are, the greater the power of the ViT over CNNs is. However, to obtain a huge crowd dataset (e.g., 300 million frames or more) is still a challenging task in computer vision.",
+                        "sortScore": 0.23015626030843434,
+                        "relevanceScore": 0.1250653713941574,
+                        "publicationScore": 0.6663414634146342,
+                        "impactFactor": 2.6,
+                        "impactFactorScore": 0.1092436974789916,
+                        "citationNums": 5,
+                        "fullText": "",
+                        "figures": null
+                      },
+                      {
+                        "sequenceId": 45,
+                        "author": [
+                          "Yujie Liu",
+                          "Zhaoyong Wang",
+                          "Wenxin Zhang",
+                          "Zongmin Li"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "In this paper, we present three major challenges in occluded person Re-Identification (ReID): different occlusions, background interference, and dataset bias. To address the first and second challenges, our approach incorporates pedestrian segmentation to distinguish between pedestrian and non-pedestrian regions. Additionally, to tackle the third challenge, we introduce an effective image enhancement method called Enhanced Random Occluding (ERO). ERO leverages other datasets with segmentation annotations to compensate for the lack of detailed annotations in ReID datasets. We compare the effectiveness of ERO with existing methods. To utilize the prior knowledge obtained by ERO, we introduce the Priori Segmentation Module (PSM) and the Domain Generalization Module (DGM). The PSM module enables learning out-of-domain prior knowledge without relying on external networks, while the DGM module transfers this knowledge to the current domain. Finally, we utilize the obtained segmentation results as attention maps for feature aggregation. ERO, PSM, and DGM together constitute the Domain Generalization Segmentation Network (DGSN). Our experimental results on occluded and holistic person ReID benchmarks demonstrate the superiority of the proposed DGSN. On the Occluded-Duke dataset, we achieved a mAP of 69.9% (+2.0%) and a rank-1 accuracy of 60.7% (+0.3%), surpassing state-of-the-art methods significantly.",
+                        "abstractZh": "在本文中，我们提出了遮挡行人重识别（ReID）中的三个主要挑战：不同的遮挡情况、背景干扰和数据集偏差。为了解决前两个挑战，我们的方法结合了行人分割，以区分行人区域和非行人区域。此外，为了应对第三个挑战，我们引入了一种名为增强随机遮挡（ERO）的有效图像增强方法。ERO利用带有分割注释的其他数据集来弥补ReID数据集中详细注释的不足。我们将ERO与现有方法的有效性进行了比较。为了利用ERO获得的先验知识，我们引入了先验分割模块（PSM）和域泛化模块（DGM）。PSM模块能够在不依赖外部网络的情况下学习域外先验知识，而DGM模块将此知识转移到当前域。最后，我们将获得的分割结果用作特征聚合的注意力图。ERO、PSM和DGM共同构成了域泛化分割网络（DGSN）。我们在遮挡和整体行人ReID基准上的实验结果证明了所提出的DGSN的优越性。在遮挡杜克数据集上，我们实现了69.9%（+2.0%）的平均精度均值（mAP）和60.7%（+0.3%）的秩-1准确率，显著超过了当前的先进方法。 ",
+                        "title": "DGSN: Learning how to segment pedestrians from other datasets for occluded person re-identification",
+                        "titleZh": "DGSN：学习如何从其他数据集中分割行人以进行遮挡行人重识别",
+                        "doi": "10.1016/j.imavis.2023.104844",
+                        "bohriumId": "949055082635198490",
+                        "publicationId": 2657,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2657.png",
+                        "publicationDate": "2023-12-01",
+                        "journal": "Image and Vision Computing",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.21487981296942357,
+                        "relevanceScore": 0.03622005507349968,
+                        "publicationScore": 0.7892682926829269,
+                        "impactFactor": 4.2,
+                        "impactFactorScore": 0.17647058823529413,
+                        "citationNums": 2,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "949055082635198490_fig2_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/2657/949055082635198490/949055082635198490_fig2_1.png",
+                            "enExplain": "This image appears to be a comparison of different methods for object retrieval or identification in video frames, likely in the context of computer - vision research.\n\n### Query Section\nOn the far left, labeled \"Query\", there are two sets of video frames. The top set shows a person with long hair, and the bottom set shows a person in a more industrial - like setting, possibly on a platform or stairs. These frames represent the input or the query for which similar frames are to be retrieved.\n\n### Vit Baseline(Top 6) Section\nIn the middle section, labeled \"Vit Baseline(Top 6)\", there are two rows of video frames. Each row contains six frames. The red boxes around the frames indicate the top 6 retrieved frames using a Vision Transformer (ViT) baseline method. The top row shows frames related to the person with long hair query, and the bottom row shows frames related to the person on the platform/stairs query. Each frame has a score displayed in the top - left corner, such as \"0.718\" and \"0.657\", which likely represents the similarity score between the query frame and the retrieved frame.\n\n### Ours(Top 6) Section\nOn the right - hand side, labeled \"Ours(Top 6)\", there are also two rows of video frames, each with six frames. The green boxes around the frames signify that these are the top 6 retrieved frames using the proposed method (referred to as \"Ours\"). Similar to the ViT baseline section, the top row corresponds to the long - haired person query, and the bottom row corresponds to the person on the platform/stairs query. Each frame has a similarity score in the top - left corner, like \"0.856\" and \"0.634\".\n\n### Overall Comparison\nThe image is likely used to demonstrate the performance improvement of the proposed method (\"Ours\") over the Vision Transformer baseline in terms of retrieving more relevant frames for the given queries. The higher scores in the \"Ours\" section suggest that the proposed method is better at finding frames that closely match the query frames compared to the baseline method. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 46,
+                        "author": [
+                          "Preksha Pareek",
+                          "Ankit Thakkar"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Human Action Recognition (HAR) involves human activity monitoring task in different areas of medical, education, entertainment, visual surveillance, video retrieval, as well as abnormal activity identification, to name a few. Due to an increase in the usage of cameras, automated systems are in demand for the classification of such activities using computationally intelligent techniques such as Machine Learning (ML) and Deep Learning (DL). In this survey, we have discussed various ML and DL techniques for HAR for the years 2011–2019. The paper discusses the characteristics of public datasets used for HAR. It also presents a survey of various action recognition techniques along with the HAR applications namely, content-based video summarization, human–computer interaction, education, healthcare, video surveillance, abnormal activity detection, sports, and entertainment. The advantages and disadvantages of action representation, dimensionality reduction, and action analysis methods are also provided. The paper discusses challenges and future directions for HAR.",
+                        "abstractZh": "人体动作识别（Human Action Recognition，HAR）涉及医疗、教育、娱乐、视觉监控、视频检索、异常活动识别等不同领域的人体活动监测任务。由于相机使用的增加，自动化系统需要使用机器学习 (ML) 和深度学习 (DL) 等计算智能技术对此类活动进行分类。在本次调查中，我们讨论了 2011-2019 年 HAR 的各种机器学习和深度学习技术。本文讨论了用于 HAR 的公共数据集的特征。它还对各种动作识别技术以及 HAR 应用进行了调查，即基于内容的视频摘要、人机交互、教育、医疗保健、视频监控、异常活动检测、体育和娱乐。还提供了动作表示、降维和动作分析方法的优缺点。本文讨论了 HAR 的挑战和未来方向。",
+                        "title": "A survey on video-based Human Action Recognition: recent updates, datasets, challenges, and applications",
+                        "titleZh": "基于视频的人类动作识别研究综述：最新进展、数据集、挑战与应用",
+                        "doi": "10.1007/s10462-020-09904-8",
+                        "bohriumId": "812563368870150144",
+                        "publicationId": 2496,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/2496.png",
+                        "publicationDate": "2020-09-25",
+                        "journal": "Artificial Intelligence Review",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.20842315165209993,
+                        "relevanceScore": 0.1233656257390976,
+                        "publicationScore": 0.2224390243902439,
+                        "impactFactor": 10.7,
+                        "impactFactorScore": 0.44957983193277307,
+                        "citationNums": 30,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "812563368870150144_fig2_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/2496/812563368870150144/812563368870150144_fig2_1.png",
+                            "enExplain": "This is a hierarchical classification diagram that organizes various types of features used in computer - vision and related fields. The top - level category is \"Features,\" which is then divided into several sub - categories:\n\n### Interest Point\nInterest points are distinctive locations in an image or a video frame.\n- **Space - Time Interest Point**: These are interest points that are defined in both spatial and temporal dimensions. They are useful for detecting local regions of interest in video sequences where motion and spatial information are combined.\n- **Color Space - Time Interest Point**: An extension of space - time interest points that also incorporate color information. This helps in more precisely identifying and differentiating regions in color video data.\n- **Scale - Invariant Feature Transform (SIFT)**: A well - known feature extraction algorithm that detects and describes local features in images. SIFT features are invariant to image scale, rotation, and illumination changes, making them very useful for object recognition and image matching tasks.\n\n### Trajectory\nTrajectories represent the path of an object or a point over time.\n- **Dense Trajectory**: It involves extracting trajectories densely over the entire video frame, capturing the motion of multiple regions in a video. This can be used for action recognition and other video - based analysis tasks.\n- **Trajectory - pooled Deep Neural Network**: This likely refers to a method that pools trajectory information and uses a deep neural network for further processing. It combines the advantages of trajectory - based features and deep learning for tasks such as video understanding.\n\n### Depth\nDepth information provides the distance of objects from the camera.\n- **Depth Motion Map**: It is a representation that combines depth and motion information. This can be useful for understanding the 3D motion of objects in a scene, especially in applications where depth perception is important, such as robotics and augmented reality.\n\n### Pose\nPose refers to the position and orientation of an object or a human body.\n- **2D**: Represents the pose in a two - dimensional space. This can be used for simple image - based analysis tasks where only planar information is considered, such as hand gesture recognition in a 2D image.\n- **3D**: Represents the pose in a three - dimensional space. This is more complex and is used in applications like 3D human motion analysis, virtual reality, and robotics for more accurate object and human pose estimation.\n\n### Motion\nMotion features describe the movement of objects in a video.\n- **Optical Flow**: It is a technique that estimates the motion of objects, surfaces, and edges in a visual scene between consecutive frames. Optical flow can be used for tasks such as motion analysis, video compression, and object tracking.\n- **Motion History Image**: It is a single - image representation that encodes the history of motion in a video sequence. It can be used to summarize motion information for action recognition and other video - analysis tasks.\n- **Motion Energy Image**: Similar to the motion history image, it represents the energy of motion in a video frame. It can be used to highlight areas of high - motion activity in a video.\n\n### Shape\nShape features describe the geometric form of objects.\n- **Silhouette**: The outline or the outer boundary of an object. Silhouettes can be used for object recognition and classification, especially when the shape of the object is a key characteristic.\n- **Histogram of Oriented Gradients (HOG)**: A feature descriptor used in computer vision and image processing for the purpose of object detection. HOG features are computed by counting the occurrences of gradient orientations in localized portions of an image.\n- **Image Moments**: They are a set of numeric features that describe the shape of an object in an image. Image moments can be used for tasks such as object identification, orientation determination, and shape - based image retrieval.\n\n### Other\nThis category includes additional types of features.\n- **Texture**: Texture features describe the surface characteristics of objects in an image, such as smoothness, roughness, and regularity. They are useful for tasks like material recognition and image segmentation.\n- **Gait**: Gait features are related to the walking pattern of humans or animals. They can be used for biometric identification and activity analysis.\n\n### Hybrid\nThe \"Hybrid\" category likely represents features or methods that combine multiple types of the above - mentioned features to achieve better performance in various computer - vision tasks. For example, combining motion and shape features to improve action recognition accuracy. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 47,
+                        "author": [
+                          "Haoran Wei",
+                          "Nasser Kehtarnavaz"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "This paper presents a semi-supervised faster region-based convolutional neural network (SF-RCNN) approach to detect persons and to classify the load carried by them in video data captured from distances several miles away via high-power lens video cameras. For detection, a set of computationally efficient image processing steps are considered to identify moving areas that may contain a person. These areas are then passed onto a faster RCNN classifier whose convolutional layers consist of ResNet50 transfer learning. Frame labels are obtained in a semi-supervised manner for the training of the faster RCNN classifier. For load classification, another convolutional neural network classifier whose convolutional layers consist of GoogleNet transfer learning is used to distinguish a person carrying a bundle from a person carrying a long arm. Despite the challenges associated with the video dataset examined in terms of the low resolution of persons, the presence of heat haze, and the shaking of the camera, it is shown that the developed approach outperforms the faster RCNN approach.",
+                        "abstractZh": "本文提出了一种半监督的基于区域的快速卷积神经网络（SF-RCNN）方法，用于检测人员并对他们在通过高倍镜头摄像机从数英里外拍摄的视频数据中所携带的负载进行分类。对于检测，考虑了一组计算效率高的图像处理步骤，以识别可能包含人员的移动区域。然后将这些区域传递给一个快速RCNN分类器，其卷积层由ResNet50迁移学习组成。以半监督方式获得帧标签，用于训练快速RCNN分类器。对于负载分类，使用另一个卷积神经网络分类器，其卷积层由GoogleNet迁移学习组成，以区分携带包裹的人和携带长臂的人。尽管在所检查的视频数据集中存在人员分辨率低、热霾的存在以及摄像机抖动等挑战，但结果表明，所开发的方法优于快速RCNN方法。 ",
+                        "title": "Semi-Supervised Faster RCNN-Based Person Detection and Load Classification for Far Field Video Surveillance",
+                        "titleZh": "基于半监督更快区域卷积神经网络的远场视频监控中的人员检测与负载分类",
+                        "doi": "10.3390/make1030044",
+                        "bohriumId": "812762392684396544",
+                        "publicationId": 51582,
+                        "publicationCover": "",
+                        "publicationDate": "2019-06-27",
+                        "journal": "Machine Learning and Knowledge Extraction",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.09852682264401849,
+                        "relevanceScore": 0.10818895697593689,
+                        "publicationScore": 0,
+                        "impactFactor": 4,
+                        "impactFactorScore": 0.1680672268907563,
+                        "citationNums": 18,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "812762392684396544_fig3_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/51582/812762392684396544/812762392684396544_fig3_1.png",
+                            "enExplain": "This is a flowchart illustrating a series of operations in an image - processing or video - processing pipeline. The following is a detailed description of each step in English:\n\n### Down - sampling\nDown - sampling is the process of reducing the number of samples in a signal or an image. In the context of image processing, it typically involves reducing the resolution of an image. This can be achieved through various methods such as averaging a group of pixels in a neighborhood to form a single pixel in the down - sampled image. Down - sampling is often used to decrease the computational complexity of subsequent operations, reduce storage requirements, or to change the scale of the image for further analysis. For example, in a video - processing application, down - sampling can be used to reduce the frame size and thus lower the bandwidth requirements for transmission.\n\n### Color to luminance conversion\nThis step converts an image from a color - based representation (such as RGB) to a luminance - based representation. Luminance represents the perceived brightness of an image. In the RGB color model, the luminance can be calculated using a weighted sum of the red, green, and blue components. For example, in the standard ITU - R BT.601 conversion for standard definition television, the luminance \\(Y\\) is calculated as \\(Y = 0.299R+ 0.587G + 0.114B\\). This conversion is useful in many applications where the brightness information of an image is more important than the color information, such as in some motion - detection algorithms or in applications where only the grayscale version of the image is required for further processing.\n\n### Frame differencing\nFrame differencing is a technique mainly used in video processing. It involves subtracting one frame from another (usually consecutive frames) in a video sequence. The resulting difference image highlights the areas where there has been a change between the two frames. This can be very useful for detecting motion in a video. For example, if an object moves from one position in one frame to another in the next frame, the frame - differencing operation will show non - zero values in the pixels corresponding to the object's movement. Frame differencing is a simple yet effective method for basic motion detection and can be used as a pre - processing step in more complex computer vision algorithms.\n\n### Convolution\nConvolution is a fundamental operation in image processing and computer vision. It involves sliding a small matrix called a kernel (or filter) over the image pixel by pixel. At each position, the kernel values are multiplied element - by - element with the corresponding pixels in the image region covered by the kernel, and the results are summed up to produce a single output pixel. Different kernels can be designed to perform various operations such as edge detection (e.g., the Sobel or Canny edge detectors use convolution), blurring (e.g., a Gaussian blur kernel), or feature extraction. Convolution helps in extracting important features from the image, enhancing certain aspects, or suppressing noise.\n\nIn summary, this flowchart represents a sequence of operations that can be used in a variety of image and video processing tasks, from reducing the data size in the initial down - sampling step to extracting features through convolution at the end, with intermediate steps for transforming the image representation and detecting changes between frames. "
+                          }
+                        ]
+                      },
+                      {
+                        "sequenceId": 48,
+                        "author": [
+                          "Arturo Tozzi",
+                          "James F. Peters"
+                        ],
+                        "link": "",
+                        "source": "Bohrium",
+                        "sourceZh": "玻尔",
+                        "abstract": "Neuroscientists draw lines of separation among structures and functions that they judge different, arbitrarily excluding or including issues in our description, to achieve positive demarcations that permits a pragmatic treatment of the nervous activity based on regularity and uniformity. However, uncertainty due to disconnectedness, lack of information and absence of objects' sharp boundaries is a troubling issue that prevents these scientists to select the required proper sets/subsets during their experimental assessment of natural and artificial neural networks. Starting from the detection of metamorphoses of shapes inside a Euclidean manifold, we propose a technique to detect the topological changes that occur during their reciprocal interactions and shape morphing. This method, that allows the detection of topological holes development and disappearance, makes it possible to solve the problem of uncertainty in the assessment of countless dynamical phenomena, such as cognitive processes, protein homeostasis deterioration, fire propagation, wireless sensor networks, migration flows, and cosmic bodies analysis.",
+                        "abstractZh": "神经科学家在他们认为不同的结构和功能之间划定界限，随意地在我们的描述中排除或纳入一些问题，以实现积极的划分，从而能够基于规律性和一致性对神经活动进行务实的处理。然而，由于不连贯性、信息缺乏以及物体边界不清晰所导致的不确定性，是一个困扰这些科学家的问题，它使得他们在对自然和人工神经网络进行实验评估时，难以选择所需的合适集合/子集。从检测欧几里得流形内形状的变形开始，我们提出了一种技术，用于检测在它们的相互作用和形状变形过程中发生的拓扑变化。这种方法能够检测拓扑空洞的形成和消失，从而有可能解决在评估无数动态现象时的不确定性问题，比如认知过程、蛋白质稳态恶化、火灾蔓延、无线传感器网络、迁移流以及天体分析等。 ",
+                        "title": "Removing uncertainty in neural networks",
+                        "titleZh": "消除神经网络中的不确定性",
+                        "doi": "10.1007/s11571-020-09574-w",
+                        "bohriumId": "812674948853137409",
+                        "publicationId": 3902,
+                        "publicationCover": "https://pubboer.tos-cn-beijing.volces.com/journal/3902.png",
+                        "publicationDate": "2020-02-27",
+                        "journal": "Cognitive Neurodynamics",
+                        "arxiv": "",
+                        "aiSummarize": "",
+                        "openAccess": "",
+                        "pdfFlag": false,
+                        "pieces": "",
+                        "sortScore": 0.07558617818752156,
+                        "relevanceScore": 0.0427221953868866,
+                        "publicationScore": 0.11951219512195121,
+                        "impactFactor": 3.1,
+                        "impactFactorScore": 0.13025210084033614,
+                        "citationNums": 4,
+                        "fullText": "",
+                        "figures": [
+                          {
+                            "figureId": "812674948853137409_fig3_1",
+                            "imageUrl": "https://pprfig.catalystplus.cn/pprfig/3902/812674948853137409/812674948853137409_fig3_1.png",
+                            "enExplain": "### Science Field and Research Direction\nThis scientific image belongs to the field of computer - vision, specifically in the research direction of image processing and object detection in video frames. The focus is on identifying and locating specific features (holes in this case) within video frame images.\n\n### Key Aspects of Image Analysis in Computer - Vision\n1. **Input and Output Definition**: Understanding what the initial input data is (a color image in a video frame) and what the desired output is (centroids of holes recorded in a video frame).\n2. **Image Transformation Steps**: Analyzing the intermediate steps of image processing such as conversion to grayscale and binary image conversion, which are crucial for feature extraction.\n3. **Feature Detection**: Examining how the specific feature (holes) is detected and marked in the image.\n\n### Detailed Image Analysis\n\n1. **Input and Output Declaration**\n   - The input is clearly stated as \"Colour image img in a video frame\", indicating that the algorithm starts with a color - based visual representation from a video sequence.\n   - The output is \"Centroids on holes recorded in a video frame\", which means the end - goal of the algorithm is to find the central points of the holes present in the video frame.\n\n2. **Image Conversion Steps**\n   - **Grayscale Conversion**: The first step is to convert the color image (`img`) to a grayscale image (`imgGrey`). This is a common pre - processing step in image processing as it simplifies the image data by reducing the color information to a single intensity channel. Mathematically, in most cases, it is a weighted sum of the red, green, and blue channels. For example, in the common luminance - based conversion, `imgGrey = 0.299 * R+ 0.587 * G + 0.114 * B`, where `R`, `G`, and `B` are the red, green, and blue components of each pixel in the color image. This step helps in reducing computational complexity and often makes subsequent processing steps more effective for feature detection.\n   - **Binary Conversion**: The grayscale image (`imgGrey`) is then converted to a binary image (`imgBW`). In a binary image, each pixel has only two possible values, typically 0 and 1. This conversion is usually based on a thresholding operation. Pixels with intensities above the threshold are set to 1 (white in a typical visual representation), and those below are set to 0 (black). This step further simplifies the image, making it easier to identify and separate different regions or features, such as the holes in this case.\n\n3. **Feature Detection**\n   - **Finding Centroids of Holes**: The final step in the algorithm is to find the centroids of the holes in the binary image. The holes are marked with a \"+\" symbol in the image. The centroid of a hole (or any region in an image) is the geometric center of that region. To calculate the centroid of a region in a binary image, one sums the x and y coordinates of all the pixels in the region and divides by the number of pixels in that region. This gives the central point of the hole, which is then marked in the original color image for visualization purposes.\n\nOverall, this image illustrates a step - by - step process in computer - vision for detecting and locating specific features (holes) within video frame images, highlighting the importance of pre - processing steps like grayscale and binary conversion in effective feature detection. "
+                          }
+                        ]
+                      }
+                    ],
+                    "sourceList": [
+                      "Bohrium"
+                    ],
+                    "logId": 7367
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Summary
- 纳入 sigma-search **v1** 的 7 个文献智能搜索接口，新建独立 tag「科学导航 (bohrium-navigator)」
- 与既有 `bohrium-mentor`（v4 深度推理 SSE）**同源不同代、能力互补**，路径零冲突

## 接口清单
| 方法 | 路径 | 用途 |
|---|---|---|
| POST | `/v1/sigma-search/api/v1/ai_search/sessions` | 创建搜索会话 |
| GET | `/v1/sigma-search/api/v1/ai_search/sessions` | 问答记录列表 |
| GET | `/v1/sigma-search/api/v1/ai_search/sessions/{uuid}` | 搜索详情 |
| POST | `/v1/sigma-search/api/v1/ai_search/sessions/{uuid}/questions` | 多轮追问 |
| GET | `/v1/sigma-search/api/v1/ai_search/questions/{queryId}` | AI 总结内容 |
| GET | `/v1/sigma-search/api/v1/ai_search/questions/{queryID}/stream` | 流式输出 |
| GET | `/v1/sigma-search/api/v1/ai_search/questions/{queryID}/papers` | 相关文献列表（可排序） |

## 与 bohrium-mentor 的区别
核心问答能力有重叠，但 v1 独有：**可排序的相关文献列表、多轮追问、问答记录列表、分子图资源**（v4 均无）。

## 说明
- 鉴权统一走全局 `bearerAuth`，移除源接口的 `accessKey` 参数（与 mentor 组一致）
- 保留 papers 列表等详细响应 schema；空 schema 接口引用 `#/components/schemas/ApiResponse`

## Test plan
- [x] JSON 校验通过（`json.load` 无异常）
- [x] 7 个接口全部归入新 tag，accessKey 参数已清理
- [x] 既有 bohrium-mentor 4 接口完好未受影响