### PR TITLE
docs: 校准 PDF Parser 响应契约

### DIFF
--- a/en/bohrium-pdf-parser/SKILL.md
+++ b/en/bohrium-pdf-parser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bohrium-pdf-parser
-description: "Parse PDF documents via open.bohrium.com. Use when: user asks about extracting text, tables, charts, formulas, or molecules from PDF files on Bohrium, submitting PDFs by URL or file upload. NOT for: file management, dataset management, or knowledge base operations."
+description: "Use when extracting text, tables, charts, formulas, or molecules from PDF files through Bohrium OpenAPI, including URL submission, file upload, asynchronous polling, or per-page results."
 ---
 
 # SKILL: Bohrium PDF Parser
@@ -29,6 +29,8 @@ BOHR_ACCESS_KEY is read from the OpenClaw config `~/.openclaw/openclaw.json`:
 ```
 
 OpenClaw automatically injects `env.BOHR_ACCESS_KEY` into the runtime.
+
+The Python examples require the third-party `requests` package. First verify that `python -c "import requests"` succeeds; if the current environment cannot provide it, use the `curl` examples in this skill.
 
 ## Common Code Template
 
@@ -72,8 +74,7 @@ r = requests.post(f"{BASE}/trigger-url-async", headers=HEADERS_JSON, json={
 })
 data = r.json()
 token = data["token"]
-print(f"Token: {token}, Status: {data['status']}")
-# Token: 57d12c5a-..., Status: undefined
+print(f"Token: {token}, PDF pages: {data.get('page_count')}")
 ```
 
 **Response Fields:**
@@ -81,9 +82,11 @@ print(f"Token: {token}, Status: {data['status']}")
 | Field | Description |
 |-------|-------------|
 | `token` | Task identifier for querying results |
-| `status` | Initial status is `undefined` |
-| `created_time` | Creation time |
-| `time_dict` | Per-stage timing (only `download_pdf` at this point) |
+| `page_count` | Total pages in the source PDF |
+| `model_version` | Parser model version selected for the task |
+| `model_version_source` | Source of the model-version selection |
+
+An asynchronous submission response does not guarantee `status`, `created_time`, or `time_dict`. Read task status from the subsequent `/get-result` response.
 
 ---
 
@@ -136,7 +139,8 @@ print(f"Status: {data['status']}, Content length: {len(data.get('content', ''))}
 | `status` | `success` / `undefined` (processing) / `failed` |
 | `token` | Task identifier |
 | `content` | Extracted text (LaTeX markup format) |
-| `pages_dict` | Per-page result dictionary |
+| `pages_dict` | Result list, not a dictionary; even with `pages=[0]`, its length may equal the source PDF's total pages, so do not infer processed pages from its length or guess the meaning of uninspected elements |
+| `result_schema_version` | Upstream result schema version; preserve it when processing or forwarding structured results |
 | `lang` | Detected language (`en` / `zh` etc.) |
 | `proc_page` / `total_page` | Processed / total pages |
 | `proc_textual` / `total_textual` | Processed / total text blocks |
@@ -288,3 +292,5 @@ curl -s -X POST "$BASE/get-result" \
 | Connection timeout | Domain/network issue | Use `open.bohrium.com`; test connectivity via `curl -I https://open.bohrium.com/openapi` |
 | Content has LaTeX markup | Normal behavior | Results use `\begin{title}` etc. to mark structure; post-process to extract plain text |
 | Large file parses slowly | Many pages or complex content | Use `pages` parameter to limit scope |
+| `ModuleNotFoundError: requests` | The current Python environment lacks `requests` | Use an environment that provides it, or use the `curl` examples in this skill |
+| `pages_dict` is longer than requested pages | List length does not necessarily equal processed pages | Use `proc_page` / `total_page` for progress and inspect the required elements themselves; do not rely on list length |

--- a/en/bohrium-pdf-parser/SKILL.md
+++ b/en/bohrium-pdf-parser/SKILL.md
@@ -30,8 +30,6 @@ BOHR_ACCESS_KEY is read from the OpenClaw config `~/.openclaw/openclaw.json`:
 
 OpenClaw automatically injects `env.BOHR_ACCESS_KEY` into the runtime.
 
-The Python examples require the third-party `requests` package. First verify that `python -c "import requests"` succeeds; if the current environment cannot provide it, use the `curl` examples in this skill.
-
 ## Common Code Template
 
 ```python
@@ -292,5 +290,4 @@ curl -s -X POST "$BASE/get-result" \
 | Connection timeout | Domain/network issue | Use `open.bohrium.com`; test connectivity via `curl -I https://open.bohrium.com/openapi` |
 | Content has LaTeX markup | Normal behavior | Results use `\begin{title}` etc. to mark structure; post-process to extract plain text |
 | Large file parses slowly | Many pages or complex content | Use `pages` parameter to limit scope |
-| `ModuleNotFoundError: requests` | The current Python environment lacks `requests` | Use an environment that provides it, or use the `curl` examples in this skill |
 | `pages_dict` is longer than requested pages | List length does not necessarily equal processed pages | Use `proc_page` / `total_page` for progress and inspect the required elements themselves; do not rely on list length |

--- a/zh/bohrium-pdf-parser/SKILL.md
+++ b/zh/bohrium-pdf-parser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bohrium-pdf-parser
-description: "Parse PDF documents via Bohrium open API. Use when: user asks about extracting text, tables, charts, formulas, or molecules from PDF files on Bohrium, submitting PDFs by URL or file upload. NOT for: file management, dataset management, or knowledge base operations."
+description: "Use when extracting text, tables, charts, formulas, or molecules from PDF files through Bohrium OpenAPI, including URL submission, file upload, asynchronous polling, or per-page results."
 ---
 
 # SKILL: Bohrium PDF 解析
@@ -29,6 +29,8 @@ BOHR_ACCESS_KEY 从 OpenClaw 配置文件 `~/.openclaw/openclaw.json` 中读取�
 ```
 
 OpenClaw 会自动将 `env.BOHR_ACCESS_KEY` 注入到运行环境。
+
+Python 示例依赖第三方包 `requests`。运行前先确认 `python -c "import requests"` 成功；当前环境无法提供该依赖时，改用本文的 `curl` 示例。
 
 ## 通用代码模板
 
@@ -101,7 +103,7 @@ r = requests.post(f"{BASE}/trigger-url-async", headers=HEADERS_JSON, json={
 })
 data = r.json()
 token = data["token"]
-print(f"Token: {token}, Status: {data['status']}")
+print(f"Token: {token}, PDF pages: {data.get('page_count')}")
 ```
 
 **响应字段：**
@@ -109,12 +111,12 @@ print(f"Token: {token}, Status: {data['status']}")
 | 字段 | 说明 |
 |------|------|
 | `token` | 任务标识，用于查询结果（网关自动生成） |
-| `status` | 初始状态为 `undefined` |
-| `created_time` | 创建时间 |
 | `page_count` | PDF 总页数 |
-| `time_dict` | 各阶段耗时 |
+| `model_version` | 本次任务使用的解析模型版本 |
+| `model_version_source` | 模型版本选择来源 |
 
 > URL 方式下网关会自动注入 `token` 字段，客户端无需自行生成。
+> 异步提交响应不保证返回 `status`、`created_time` 或 `time_dict`；任务状态以随后 `/get-result` 的响应为准。
 
 ---
 
@@ -179,7 +181,8 @@ print(f"Status: {data['status']}, Content length: {len(data.get('content', ''))}
 | `status` | `success` / `undefined`（排队中）/ `processing` / `failed` |
 | `token` | 任务标识 |
 | `content` | 解析出的文本（LaTeX 标记格式） |
-| `pages_dict` | 按页的解析结果列表（当前接口返回 list，不要假设为 dict） |
+| `pages_dict` | 结果列表（不是 dict）；即使 `pages=[0]`，列表长度也可能等于源 PDF 总页数，不要用其长度推断处理页数，也不要猜测未检查元素的语义 |
+| `result_schema_version` | 上游返回的结果结构版本；处理或转交结构化结果时一并保留 |
 | `lang` | 检测到的语言（`en` / `zh` 等） |
 | `proc_page` / `total_page` | 已处理/总页数 |
 | `proc_textual` / `total_textual` | 已处理/总文本块数 |
@@ -319,3 +322,5 @@ curl -s -X POST "$BASE/get-result" \
 | content 含 LaTeX 标记 | 正常行为 | 解析结果用 `\begin{title}` 等标记段落结构，需后处理提取纯文本 |
 | 大文件解析慢 | 页数多或内容复杂 | 用 `pages` 参数指定需要的页码，减少解析范围 |
 | `figure` 返回 403 | AccessKey 无该模块权限 | 设置 `figure: 0` 禁用，或联系平台开通权限 |
+| `ModuleNotFoundError: requests` | 当前 Python 环境未安装 `requests` | 使用已提供该依赖的环境，或改用本文的 `curl` 示例 |
+| `pages_dict` 长度大于请求页数 | 列表长度与实际处理页数不一定一致 | 使用 `proc_page` / `total_page` 判断处理进度，并检查所需元素本身，不要依赖列表长度 |

--- a/zh/bohrium-pdf-parser/SKILL.md
+++ b/zh/bohrium-pdf-parser/SKILL.md
@@ -30,8 +30,6 @@ BOHR_ACCESS_KEY 从 OpenClaw 配置文件 `~/.openclaw/openclaw.json` 中读取�
 
 OpenClaw 会自动将 `env.BOHR_ACCESS_KEY` 注入到运行环境。
 
-Python 示例依赖第三方包 `requests`。运行前先确认 `python -c "import requests"` 成功；当前环境无法提供该依赖时，改用本文的 `curl` 示例。
-
 ## 通用代码模板
 
 ```python
@@ -322,5 +320,4 @@ curl -s -X POST "$BASE/get-result" \
 | content 含 LaTeX 标记 | 正常行为 | 解析结果用 `\begin{title}` 等标记段落结构，需后处理提取纯文本 |
 | 大文件解析慢 | 页数多或内容复杂 | 用 `pages` 参数指定需要的页码，减少解析范围 |
 | `figure` 返回 403 | AccessKey 无该模块权限 | 设置 `figure: 0` 禁用，或联系平台开通权限 |
-| `ModuleNotFoundError: requests` | 当前 Python 环境未安装 `requests` | 使用已提供该依赖的环境，或改用本文的 `curl` 示例 |
 | `pages_dict` 长度大于请求页数 | 列表长度与实际处理页数不一定一致 | 使用 `proc_page` / `total_page` 判断处理进度，并检查所需元素本身，不要依赖列表长度 |


### PR DESCRIPTION
## 变更
- 修正异步提交响应字段，避免读取不存在的 status
- 明确 pages_dict 的实际列表语义与 result_schema_version 的保留要求
- 补充 requests 依赖检查及 curl 替代路径

## 验证
- 中英文 Skill quick_validate 均通过
- 12 个 Python 示例代码块语法检查通过
- go test ./... 通过
- 生产 OpenAPI 实测：提交 HTTP 200，轮询成功；pages_dict 为 list，proc_page/total_page 为 1/1