### PR TITLE
更新 Bohrium Skills 首页，推荐使用 bohr CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,81 +1,123 @@
-# Bohrium Skill Hub
+# Bohrium Skills
 
-Bohrium 平台 AI 技能集合，为 [OpenClaw](https://github.com/openclaw) 和 [Claude Code](https://claude.com/claude-code) 提供结构化的 SKILL.md 文件。每个 skill 描述一个独立能力（API 调用、Agent 工作流等），供 AI 编码助手在对话中按需加载。
+Bohrium 科研计算平台的 AI Agent 技能集合。
+
+> 新接入用户推荐使用 [Bohrium CLI（`bohr`）](https://www.bohrium.com/bohr-cli/intro)。`bohr` 提供统一的平台命令，并内嵌与当前 CLI 版本匹配的 Agent Skills。本仓库继续保留独立的 `SKILL.md`，供已有集成使用。
 
 [English](README_EN.md)
 
----
+## 使用 Bohrium CLI
 
-## 认证配置
+### 安装
 
-所有 API Skills 需要 Bohrium AccessKey 作为鉴权凭证。
+```bash
+npm install -g @dptech-corp/bohr-cli
+```
 
-### 获取 AccessKey
+支持 macOS、Linux 和 Windows 的 x64 / arm64 环境。安装后推荐先通过浏览器登录 Bohrium 账号：
 
-1. 注册 [Bohrium](https://www.bohrium.com/)（机构用户请联系深势科技商务 bd@dp.tech 开通机构账号）
-2. 登录后进入 [用户设置 → 账号页面](https://www.bohrium.com/settings/account)，复制 AccessKey
+```bash
+bohr auth login    # 登录 Bohrium 账号
+bohr doctor        # 检查本地配置与连接
+bohr --help        # 查看全部命令
+```
+
+### 常用命令
+
+先通过根命令查看 Bohrium CLI 提供的能力，再进入对应命令查看子命令和参数：
+
+```bash
+bohr --help
+bohr wiki --help
+bohr wiki search --help
+```
+
+其他能力同样按层级查看，例如：
+
+```bash
+bohr job --help
+bohr sandbox --help
+bohr lkm --help
+bohr agents mentor --help
+```
+
+本仓库每个独立 Skill 对应的 `bohr` 命令见下方清单。具体子命令和参数始终以当前 CLI 的 `--help` 输出为准。
+
+### Agent Skills
+
+`bohr` 内嵌了适合 AI Agent 使用的命令指南，内容与 CLI 版本绑定。先查看当前版本已经覆盖的 Skills；未列出的命令仍可通过 `bohr <command> --help` 获取参数说明：
+
+```bash
+bohr skills list                              # 列出当前版本内嵌的 Skills
+bohr skills read bohr-sandbox                 # 读取一个 Skill
+bohr skills list bohr-sandbox/references      # 列出 Skill 的参考资料
+```
+
+升级 CLI 即可获得新版本命令及其配套 Skills：
+
+```bash
+bohr update
+```
+
+## 帮助与文档
+
+- [Bohrium CLI 产品介绍](https://www.bohrium.com/bohr-cli/intro)
+- [Bohrium CLI 安装文档](https://docs.bohrium.com/docs/bohrctl/install/)
+- [Bohrium CLI 计费说明](https://docs.bohrium.com/docs/bohrctl/pricing)
+- [Bohrium CLI npm 页面](https://www.npmjs.com/package/@dptech-corp/bohr-cli)
+- [Bohrium 平台](https://www.bohrium.com/)
+- 命令内帮助：`bohr --help`、`bohr <command> --help`
+
+## 本仓库中的独立 Skills
+
+以下 `SKILL.md` 继续保留，供已经依赖本仓库的 Agent 或自动化环境使用。新接入场景推荐使用 `bohr` 及其内嵌 Skills。
+
+### 已有集成配置
+
+> 本节仅适用于继续直接使用本仓库独立 Skills 的已有集成。新接入用户仍推荐安装 `bohr` 并运行 `bohr auth login`。
+
+直接调用平台 API 的独立 Skills 需要 Bohrium AccessKey。可在 [Bohrium 用户设置](https://www.bohrium.com/settings/account) 中获取，然后通过环境变量提供：
 
 ![获取 AccessKey](docs/images/access-key-settings.png)
 
-### 配置方式
-
-根据运行环境选择其一：
-
-**环境变量**（Claude Code / 通用）：
-
 ```bash
-export BOHR_ACCESS_KEY="your_access_key_here"
+export BOHR_ACCESS_KEY="YOUR_ACCESS_KEY"
 ```
 
-**OpenClaw 配置文件** `~/.openclaw/openclaw.json`：
+请勿将真实凭据写入代码或提交到仓库。
 
-```json
-{
-  "skills": {
-    "<skill-name>": {
-      "enabled": true,
-      "apiKey": "YOUR_BOHR_ACCESS_KEY",
-      "env": {
-        "BOHR_ACCESS_KEY": "YOUR_BOHR_ACCESS_KEY"
-      }
-    }
-  }
-}
+已有 Claude Code 插件用户可以继续使用原安装方式：
+
+```text
+/plugin marketplace add dptech-corp/bohrium-skills
+/plugin install bohrium-skills@bohrium
 ```
 
----
+### Skill 列表
 
-## Skill 列表
-
-### 平台 API Skills
-
-通过 `bohr` CLI 或 `open.bohrium.com` HTTP API 操作 Bohrium 平台资源。
-
-| Skill | 说明 |
-|-------|------|
-| [bohrium-job](zh/bohrium-job/SKILL.md) | 计算任务管理 — 提交、查询、终止、删除任务 |
-| [bohrium-node](zh/bohrium-node/SKILL.md) | 开发节点管理 — 创建、启停、删除容器/虚拟机 |
-| [bohrium-dataset](zh/bohrium-dataset/SKILL.md) | 数据集管理 — 创建、上传、下载、版本控制 |
-| [bohrium-file](zh/bohrium-file/SKILL.md) | 文件盘管理 — 列出、上传、下载、移动、复制、删除 personal/share 盘文件 |
-| [bohrium-database](zh/bohrium-database/SKILL.md) | 私有数据库 — 查询库表结构、增删改查数据、新建表和修改表结构 |
-| [bohrium-image](zh/bohrium-image/SKILL.md) | 容器镜像管理 — 查询、拉取、创建、删除镜像 |
-| [bohrium-project](zh/bohrium-project/SKILL.md) | 项目管理 — 创建项目、管理成员、设置额度 |
-| [bohrium-knowledge-base](zh/bohrium-knowledge-base/SKILL.md) | 知识库管理 — 文献管理、标签、笔记、召回搜索 |
-| [bohrium-paper-search](zh/bohrium-paper-search/SKILL.md) | 论文与专利搜索 — RAG 引擎关键词+语义检索 |
-| [bohrium-pdf-parser](zh/bohrium-pdf-parser/SKILL.md) | PDF 解析 — 提取文本、表格、图表、公式 |
-| [bohrium-scholar-search](zh/bohrium-scholar-search/SKILL.md) | 学者搜索与画像 — 按姓名/机构检索，查看发文/引用/h-index/研究方向 |
-| [bohrium-sciencepedia](zh/bohrium-sciencepedia/SKILL.md) | 科学百科 — 搜词条/关键词拿简介与链接、浏览领域课程、看课程章节知识点、查主题知识图谱 |
-| [bohrium-tools](zh/bohrium-tools/SKILL.md) | 科学工具库 — 按领域/子领域浏览、混合检索工具、查看工具详情与分类 |
-| [bohrium-web-search](zh/bohrium-web-search/SKILL.md) | 网页搜索 — 代理 searchapi.io 做开放互联网检索 |
-| [bohrium-sandbox](zh/bohrium-sandbox/SKILL.md) | 云沙箱 — 按需创建临时云 VM，运行 shell/Python |
-| [bohrium-lkm](zh/bohrium-lkm/SKILL.md) | 大知识模型 — 知识节点检索、推理链检索、论文知识图谱、追溯 claim 依据、批量节点水合、提交反馈 |
-| [bohrium-mentor](zh/bohrium-mentor/SKILL.md) | AI 科学小导师 — 基于深度推理的科学问答，自动检索文献并结构化作答 |
-
----
+| Skill | 对应 `bohr` 命令 | 说明 |
+|-------|------------------|------|
+| [bohrium-job](zh/bohrium-job/SKILL.md) | `bohr job` | 计算任务管理 — 提交、查询、终止、删除任务 |
+| [bohrium-node](zh/bohrium-node/SKILL.md) | `bohr node` | 开发节点管理 — 创建、启停、删除容器/虚拟机 |
+| [bohrium-dataset](zh/bohrium-dataset/SKILL.md) | `bohr dataset` | 数据集管理 — 创建、上传、下载、版本控制 |
+| [bohrium-file](zh/bohrium-file/SKILL.md) | `bohr file` | 文件盘管理 — 列出、上传、下载、移动、复制、删除 personal/share 盘文件 |
+| [bohrium-database](zh/bohrium-database/SKILL.md) | `bohr database` | 科学数据库 — 浏览领域数据库和表格数据 |
+| [bohrium-image](zh/bohrium-image/SKILL.md) | `bohr image` | 容器镜像管理 — 查询、拉取、创建、删除镜像 |
+| [bohrium-project](zh/bohrium-project/SKILL.md) | `bohr project` | 项目管理 — 创建项目、管理成员、设置额度 |
+| [bohrium-knowledge-base](zh/bohrium-knowledge-base/SKILL.md) | `bohr kb` | 知识库管理 — 文献管理、标签、笔记、召回搜索 |
+| [bohrium-paper-search](zh/bohrium-paper-search/SKILL.md) | `bohr paper` | 论文与专利搜索 — 关键词与语义检索 |
+| [bohrium-pdf-parser](zh/bohrium-pdf-parser/SKILL.md) | `bohr pdf` | PDF 解析 — 提取文本、表格、图表、公式 |
+| [bohrium-scholar-search](zh/bohrium-scholar-search/SKILL.md) | `bohr scholar` | 学者搜索与画像 — 检索学者及其科研成果与指标 |
+| [bohrium-sciencepedia](zh/bohrium-sciencepedia/SKILL.md) | `bohr wiki` | 科学百科 — 搜索词条、课程、知识点和知识图谱 |
+| [bohrium-tools](zh/bohrium-tools/SKILL.md) | `bohr tools` | 科学工具库 — 浏览、检索并查看工具详情 |
+| [bohrium-web-search](zh/bohrium-web-search/SKILL.md) | `bohr search` | 网页搜索 — 开放互联网检索 |
+| [bohrium-sandbox](zh/bohrium-sandbox/SKILL.md) | `bohr sandbox` | 云沙箱 — 创建临时云 VM 并运行 Shell/Python |
+| [bohrium-lkm](zh/bohrium-lkm/SKILL.md) | `bohr lkm` | 大知识模型 — 知识检索、推理链和论文知识图谱 |
+| [bohrium-mentor](zh/bohrium-mentor/SKILL.md) | `bohr agents mentor` | AI 科学小导师 — 基于文献检索的科学问答 |
 
 ## 计费说明
 
-收费 Skill 按调用或机时扣账户余额，可在 [科研资产](https://www.bohrium.com/assets) 查看余额与账单：
+收费 Skill 按调用或机时扣账户余额，可在 [科研资产](https://www.bohrium.com/assets) 查看余额与账单。最新计费规则以 [Bohrium CLI 计费说明](https://docs.bohrium.com/docs/bohrctl/pricing) 为准：
 
 | Skill | 是否收费 | 定价 | 计价单位 | 定价说明 |
 |-------|:------:|------|------|------|
@@ -90,52 +132,20 @@ export BOHR_ACCESS_KEY="your_access_key_here"
 | bohrium-tools | 收费 | 与 SciencePedia 共享每月前 1000 次免费，之后 0.01 元/次起 | 元/次 | search/hybrid 0.01 元/次；detail 0.02 元/次 |
 | bohrium-dataset / bohrium-image / bohrium-project / bohrium-knowledge-base / bohrium-scholar-search / bohrium-web-search | 免费 | - | - | - |
 
----
-
-## 安装
-
-### 方式一：Claude Code 插件
-
-```
-/plugin marketplace add dptech-corp/bohrium-skills
-/plugin install bohrium-skills@bohrium
-```
-
-### 方式二：bohrium-skills-cli（推荐）
-
-```bash
-npm install -g bohrium-skills-cli
-```
-
-安装后自动将中文版 skills 同步到 `~/.agents/skills`、`~/.claude/skills`、`~/.codex/skills`。更新：
-
-```bash
-bohrium-skills-cli update
-```
-
-> 更多安装方式（手动二进制、环境变量、常用命令等）见 [CLI 详细指南](docs/cli.md)。
-
----
-
 ## 目录结构
 
-```
-bohrium-skill-hub/
-├── zh/                          # 中文版
-│   ├── bohrium-job/SKILL.md
-│   ├── bohrium-node/SKILL.md
-│   └── ...
-├── en/                          # English version
-│   ├── bohrium-job/SKILL.md
-│   └── ...
-├── docs/images/                 # 文档图片
-├── README.md                    # 中文说明（本文件）
-└── README_EN.md                 # English README
+```text
+bohrium-skills/
+├── zh/              # 中文 Skills
+├── en/              # English Skills
+├── docs/            # 历史文档与资源
+├── README.md        # 中文首页（本文件）
+└── README_EN.md     # English README
 ```
 
 ## SKILL.md 格式规范
 
-每个 SKILL.md 至少包含：
+每个 `SKILL.md` 至少包含：
 
 ```yaml
 ---
@@ -144,11 +154,9 @@ description: "一行描述。Use when: ... NOT for: ..."
 ---
 ```
 
-- **Frontmatter** — `name` + `description`（含使用场景和排除场景）；可选添加 `version`、`metadata.openclaw.primaryEnv`
-- **正文** — 功能说明、API 端点、参数表、返回字段、代码示例、错误处理
-- **代码示例** — 使用 Python `requests` 风格，优先通过 `os.environ.get("BOHR_ACCESS_KEY")` 读取密钥，不硬编码
-
----
+- **Frontmatter** — `name` + `description`（含使用场景和排除场景）；可选添加 `version`。
+- **正文** — 功能说明、API 端点、参数表、返回字段、代码示例、错误处理。
+- **代码示例** — 使用 Python `requests` 风格，不硬编码任何凭据。
 
 ## License
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,81 +1,123 @@
-# Bohrium Skill Hub
+# Bohrium Skills
 
-A collection of AI skills for the Bohrium platform, providing structured SKILL.md files for [OpenClaw](https://github.com/openclaw) and [Claude Code](https://claude.com/claude-code). Each skill describes a standalone capability (API calls, Agent workflows, etc.) that AI coding assistants can load on demand during conversations.
+AI Agent skills for the Bohrium scientific computing platform.
+
+> For new integrations, we recommend starting with [Bohrium CLI (`bohr`)](https://www.bohrium.com/bohr-cli/intro). It provides a unified command-line interface and embeds Agent Skills that match the installed CLI version. This repository continues to keep the standalone `SKILL.md` files available for existing integrations.
 
 [中文](README.md)
 
----
+## Use Bohrium CLI
 
-## Authentication
+### Install
 
-All API Skills require a Bohrium AccessKey for authentication.
+```bash
+npm install -g @dptech-corp/bohr-cli
+```
 
-### Get your AccessKey
+The package supports x64 and arm64 on macOS, Linux, and Windows. After installation, we recommend signing in to your Bohrium account through the browser:
 
-1. Register on [Bohrium](https://www.bohrium.com/) (enterprise users should contact DP Technology sales at bd@dp.tech)
-2. Log in and go to [Settings → Account](https://www.bohrium.com/settings/account), copy your AccessKey
+```bash
+bohr auth login    # Sign in to Bohrium
+bohr doctor        # Check local configuration and connectivity
+bohr --help        # List all commands
+```
+
+### Common commands
+
+Start with the root command to discover Bohrium CLI capabilities, then enter a command namespace to inspect its subcommands and options:
+
+```bash
+bohr --help
+bohr wiki --help
+bohr wiki search --help
+```
+
+Other capabilities follow the same pattern:
+
+```bash
+bohr job --help
+bohr sandbox --help
+bohr lkm --help
+bohr agents mentor --help
+```
+
+The `bohr` command corresponding to each standalone Skill is listed below. Always use the installed CLI's `--help` output as the source of truth for subcommands and options.
+
+### Agent Skills
+
+`bohr` embeds command guidance designed for AI Agents, versioned together with the CLI. First check which Skills are available in the installed version; commands not listed there remain discoverable through `bohr <command> --help`:
+
+```bash
+bohr skills list                              # List Skills embedded in this version
+bohr skills read bohr-sandbox                 # Read a Skill
+bohr skills list bohr-sandbox/references      # List a Skill's references
+```
+
+Upgrade the CLI to receive new commands and their matching Skills:
+
+```bash
+bohr update
+```
+
+## Help and documentation
+
+- [Bohrium CLI overview](https://www.bohrium.com/bohr-cli/intro)
+- [Bohrium CLI installation guide](https://docs.bohrium.com/docs/bohrctl/install/)
+- [Bohrium CLI pricing](https://docs.bohrium.com/docs/bohrctl/pricing)
+- [Bohrium CLI on npm](https://www.npmjs.com/package/@dptech-corp/bohr-cli)
+- [Bohrium platform](https://www.bohrium.com/)
+- In-command help: `bohr --help`, `bohr <command> --help`
+
+## Standalone Skills in this repository
+
+The following `SKILL.md` files remain available for Agents and automation that already depend on this repository. New integrations should prefer `bohr` and its embedded Skills.
+
+### Existing integration configuration
+
+> This section applies only to existing integrations that continue to use the standalone Skills in this repository directly. For new integrations, we still recommend installing `bohr` and running `bohr auth login`.
+
+Standalone Skills that call the platform API directly require a Bohrium AccessKey. Get one from [Bohrium account settings](https://www.bohrium.com/settings/account), then provide it through an environment variable:
 
 ![Get AccessKey](docs/images/access-key-settings.png)
 
-### Configuration
-
-Choose one based on your runtime environment:
-
-**Environment variable** (Claude Code / general):
-
 ```bash
-export BOHR_ACCESS_KEY="your_access_key_here"
+export BOHR_ACCESS_KEY="YOUR_ACCESS_KEY"
 ```
 
-**OpenClaw config** `~/.openclaw/openclaw.json`:
+Never hard-code or commit real credentials.
 
-```json
-{
-  "skills": {
-    "<skill-name>": {
-      "enabled": true,
-      "apiKey": "YOUR_BOHR_ACCESS_KEY",
-      "env": {
-        "BOHR_ACCESS_KEY": "YOUR_BOHR_ACCESS_KEY"
-      }
-    }
-  }
-}
+Existing Claude Code plugin users can continue to use the original installation method:
+
+```text
+/plugin marketplace add dptech-corp/bohrium-skills
+/plugin install bohrium-skills@bohrium
 ```
 
----
+### Skill list
 
-## Skill List
-
-### Platform API Skills
-
-Operate Bohrium platform resources via `bohr` CLI or `open.bohrium.com` HTTP API.
-
-| Skill | Description |
-|-------|------------|
-| [bohrium-job](en/bohrium-job/SKILL.md) | Compute job management — submit, list, kill, delete jobs |
-| [bohrium-node](en/bohrium-node/SKILL.md) | Dev node management — create, start, stop, delete containers/VMs |
-| [bohrium-dataset](en/bohrium-dataset/SKILL.md) | Dataset management — create, upload, download, version control |
-| [bohrium-file](en/bohrium-file/SKILL.md) | File disk management — list, upload, download, move, copy, and delete personal/share disk files |
-| [bohrium-database](en/bohrium-database/SKILL.md) | Private database — inspect schemas, query/filter/export rows, insert/update/delete records, create and alter tables |
-| [bohrium-image](en/bohrium-image/SKILL.md) | Container image management — list, pull, create, delete images |
-| [bohrium-project](en/bohrium-project/SKILL.md) | Project management — create projects, manage members, set budgets |
-| [bohrium-knowledge-base](en/bohrium-knowledge-base/SKILL.md) | Knowledge base management — literature, tags, notes, recall search |
-| [bohrium-paper-search](en/bohrium-paper-search/SKILL.md) | Paper & patent search — RAG engine keyword + semantic retrieval |
-| [bohrium-pdf-parser](en/bohrium-pdf-parser/SKILL.md) | PDF parsing — extract text, tables, charts, formulas |
-| [bohrium-scholar-search](en/bohrium-scholar-search/SKILL.md) | Scholar search & profile — find scholars by name/affiliation, view papers/citations/h-index/research directions |
-| [bohrium-sciencepedia](en/bohrium-sciencepedia/SKILL.md) | SciencePedia — search topics/keywords for summaries & links, browse fields & courses, get a course's chapters & knowledge points, explore a topic's knowledge graph |
-| [bohrium-tools](en/bohrium-tools/SKILL.md) | Scientific Tools library — browse by domain/subdomain, hybrid-search tools, view tool details & taxonomy |
-| [bohrium-web-search](en/bohrium-web-search/SKILL.md) | Web search — proxy to searchapi.io for open internet search |
-| [bohrium-sandbox](en/bohrium-sandbox/SKILL.md) | Cloud sandbox — on-demand temp VM for running shell/Python |
-| [bohrium-lkm](en/bohrium-lkm/SKILL.md) | Large Knowledge Model — node search, reasoning-chain retrieval, paper knowledge graphs, claim provenance tracing, batch node hydration, feedback submission |
-| [bohrium-mentor](en/bohrium-mentor/SKILL.md) | AI Science Mentor — deep-reasoning scientific Q&A with automatic literature retrieval, structured Markdown answers |
-
----
+| Skill | Corresponding `bohr` command | Description |
+|-------|------------------------------|-------------|
+| [bohrium-job](en/bohrium-job/SKILL.md) | `bohr job` | Compute job management — submit, query, stop, and delete jobs |
+| [bohrium-node](en/bohrium-node/SKILL.md) | `bohr node` | Development node management — create, start, stop, and delete containers/VMs |
+| [bohrium-dataset](en/bohrium-dataset/SKILL.md) | `bohr dataset` | Dataset management — create, upload, download, and version datasets |
+| [bohrium-file](en/bohrium-file/SKILL.md) | `bohr file` | File storage management — list, upload, download, move, copy, and delete files |
+| [bohrium-database](en/bohrium-database/SKILL.md) | `bohr database` | Scientific databases — browse domain libraries and tabular data |
+| [bohrium-image](en/bohrium-image/SKILL.md) | `bohr image` | Container image management — list, pull, create, and delete images |
+| [bohrium-project](en/bohrium-project/SKILL.md) | `bohr project` | Project management — create projects, manage members, and set budgets |
+| [bohrium-knowledge-base](en/bohrium-knowledge-base/SKILL.md) | `bohr kb` | Knowledge base management — literature, tags, notes, and recall search |
+| [bohrium-paper-search](en/bohrium-paper-search/SKILL.md) | `bohr paper` | Paper and patent search — keyword and semantic retrieval |
+| [bohrium-pdf-parser](en/bohrium-pdf-parser/SKILL.md) | `bohr pdf` | PDF parsing — extract text, tables, charts, and formulas |
+| [bohrium-scholar-search](en/bohrium-scholar-search/SKILL.md) | `bohr scholar` | Scholar search and profiles — publications, citations, metrics, and research areas |
+| [bohrium-sciencepedia](en/bohrium-sciencepedia/SKILL.md) | `bohr wiki` | SciencePedia — search topics, courses, knowledge points, and knowledge graphs |
+| [bohrium-tools](en/bohrium-tools/SKILL.md) | `bohr tools` | Scientific tools — browse, search, and inspect tools |
+| [bohrium-web-search](en/bohrium-web-search/SKILL.md) | `bohr search` | Web search — search the open internet |
+| [bohrium-sandbox](en/bohrium-sandbox/SKILL.md) | `bohr sandbox` | Cloud sandbox — create temporary VMs and run Shell/Python |
+| [bohrium-lkm](en/bohrium-lkm/SKILL.md) | `bohr lkm` | Large Knowledge Model — knowledge retrieval, reasoning chains, and paper graphs |
+| [bohrium-mentor](en/bohrium-mentor/SKILL.md) | `bohr agents mentor` | AI Science Mentor — literature-grounded scientific Q&A |
 
 ## Billing
 
-Charged skills bill your account balance per call or per compute-hour. Check your balance and bills on the [Research Assets](https://www.bohrium.com/en/assets):
+Charged skills bill your account balance per call or per compute-hour. Check your balance and bills on the [Research Assets](https://www.bohrium.com/en/assets). Refer to [Bohrium CLI pricing](https://docs.bohrium.com/docs/bohrctl/pricing) for the latest pricing rules:
 
 | Skill | Charged | Price | Unit | Notes |
 |-------|:-------:|-------|------|-------|
@@ -90,52 +132,20 @@ Charged skills bill your account balance per call or per compute-hour. Check you
 | bohrium-tools | Yes | First 1,000 calls/month shared with SciencePedia are free; then from ¥0.01/call | ¥/call | search/hybrid ¥0.01/call; detail ¥0.02/call |
 | bohrium-dataset / bohrium-image / bohrium-project / bohrium-knowledge-base / bohrium-scholar-search / bohrium-web-search | Free | - | - | - |
 
----
+## Repository structure
 
-## Installation
-
-### Option 1: Claude Code Plugin
-
-```
-/plugin marketplace add dptech-corp/bohrium-skills
-/plugin install bohrium-skills@bohrium
-```
-
-### Option 2: bohrium-skills-cli (recommended)
-
-```bash
-npm install -g bohrium-skills-cli
+```text
+bohrium-skills/
+├── zh/              # Chinese Skills
+├── en/              # English Skills
+├── docs/            # Legacy documentation and assets
+├── README.md        # Chinese README
+└── README_EN.md     # English README (this file)
 ```
 
-After install, skills are automatically synced to `~/.agents/skills`, `~/.claude/skills`, and `~/.codex/skills`. To update:
+## SKILL.md format
 
-```bash
-bohrium-skills-cli update
-```
-
-> For more options (manual binary install, env vars, all commands) see [CLI Guide](docs/cli.md).
-
----
-
-## Directory Structure
-
-```
-bohrium-skill-hub/
-├── zh/                          # Chinese version
-│   ├── bohrium-job/SKILL.md
-│   ├── bohrium-node/SKILL.md
-│   └── ...
-├── en/                          # English version
-│   ├── bohrium-job/SKILL.md
-│   └── ...
-├── docs/images/                 # Documentation images
-├── README.md                    # Chinese README
-└── README_EN.md                 # English README (this file)
-```
-
-## SKILL.md Format
-
-Each SKILL.md contains at least:
+Each `SKILL.md` contains at least:
 
 ```yaml
 ---
@@ -144,11 +154,9 @@ description: "One-line description. Use when: ... NOT for: ..."
 ---
 ```
 
-- **Frontmatter** — `name` + `description` (with use/exclusion scenarios); optionally `version` and `metadata.openclaw.primaryEnv`
-- **Body** — Feature description, API endpoints, parameter tables, response fields, code examples, error handling
-- **Code examples** — Python `requests` style, preferring `os.environ.get("BOHR_ACCESS_KEY")`, never hardcoded
-
----
+- **Frontmatter** — `name` + `description` with use and exclusion scenarios; `version` is optional.
+- **Body** — Feature description, API endpoints, parameter tables, response fields, code examples, and error handling.
+- **Code examples** — Use Python `requests` style and never hard-code credentials.
 
 ## License
 


### PR DESCRIPTION
## 变更说明

- 重写中英文 README 首页，推荐新用户使用 Bohrium CLI 和浏览器登录
- 补充 CLI 产品介绍、安装、计费及 npm 页面链接
- 说明通过分级 help 查看各能力，并为 17 个独立 Skill 标注对应的 bohr 命令
- 保留已有独立 Skills 的 AccessKey 环境变量与 Claude Code 插件配置
- 保留原有 Skill 清单、计费说明和 SKILL.md 格式规范
- 移除首页中的 OpenClaw 配置及 bohrium-skills-cli 推荐

## 验证

- 使用 bohr 2.6.48 验证 README 中涉及的命令入口
- 产品介绍、安装文档和计费链接均返回 HTTP 200
- git diff --check 通过

## 提交

- 8d50c0e 更新「Bohrium Skills 首页」

## 变更文件

- README.md
- README_EN.md